### PR TITLE
solved(SWEA1873 / D3): 상호의 배틀필드

### DIFF
--- a/cjh/SWEA/Python/swea1873.py
+++ b/cjh/SWEA/Python/swea1873.py
@@ -1,0 +1,65 @@
+t = int(input())
+for test_case in range(1, t + 1):
+    h, w = map(int, input().split())
+    field = []
+    for _ in range(h):
+        field.append(list(input()))
+
+    n = int(input())
+    commands = input()
+    
+    # 초기 상태 파악
+    for i in range(h):
+        for j in range(w):
+            if field[i][j] in ["^", "v", "<", ">"]:
+                current_i = i
+                current_j = j
+                dir = field[i][j]
+
+    # 이동 설정
+    di = {"U":-1, "D":1, "L":0, "R":0}
+    dj = {"U":0, "D":0, "L":-1, "R":1}
+    c = {"U":"^", "D":"v", "L":"<", "R":">"}
+
+    # 커맨드 처리
+    for command in commands:
+        if command != "S":
+            next_i = current_i+di[command]
+            next_j = current_j+dj[command]
+            dir = c[command]
+
+            if 0 <= next_i < h and 0 <= next_j < w:
+                if field[next_i][next_j] == ".":
+                    field[current_i][current_j] = "."
+                    field[next_i][next_j] = dir
+                    current_i = next_i
+                    current_j = next_j
+                else:
+                    field[current_i][current_j] = dir
+            else:
+                field[current_i][current_j] = dir
+        else:
+            for each in c:
+                if c[each] == dir:
+                    shoot_command = each
+
+            shoot_i = current_i
+            shoot_j = current_j
+            
+            while True:
+                shoot_next_i = shoot_i+di[shoot_command]
+                shoot_next_j = shoot_j+dj[shoot_command]
+                if not (0 <= shoot_next_i < h and 0 <= shoot_next_j < w):
+                    break
+                if field[shoot_next_i][shoot_next_j] == "#":
+                    break
+                elif field[shoot_next_i][shoot_next_j] == "*":
+                    field[shoot_next_i][shoot_next_j] = "."
+                    break
+                else:
+                    shoot_i = shoot_next_i
+                    shoot_j = shoot_next_j
+
+    print(f"#{test_case}", end=" ")
+    for i in field:
+        print("".join(i))


### PR DESCRIPTION
<!-- ----- 여기부터 복사 ----- -->
---
## 🎈swea - 상호의 배틀필드
<br>
상호는 전차로 시가전을 하는 것을 테마로 한 새로운 게임 “배틀 필드”를 개발하기로 했다.

그래서 먼저 간단하게 프로토 타입 게임을 만들었다.

이 프로토 타입에서 등장하는 전차는 사용자의 전차 하나뿐이며, 적이나 아군으로 만들어진 전차는 등장하지 않는다.

사용자의 전차는 사용자의 입력에 따라 격자판으로 이루어진 게임 맵에서 다양한 동작을 한다.

다음 표는 게임 맵의 구성 요소를 나타낸다.
 
문자	의미
.	평지(전차가 들어갈 수 있다.)
*	벽돌로 만들어진 벽
#	강철로 만들어진 벽
-	물(전차는 들어갈 수 없다.)
^	위쪽을 바라보는 전차(아래는 평지이다.)
v	아래쪽을 바라보는 전차(아래는 평지이다.)
<	왼쪽을 바라보는 전차(아래는 평지이다.)
>	오른쪽을 바라보는 전차(아래는 평지이다.)

다음 표는 사용자가 넣을 수 있는 입력의 종류를 나타낸다.
 
문자	동작
U	Up : 전차가 바라보는 방향을 위쪽으로 바꾸고, 한 칸 위의 칸이 평지라면 위 그 칸으로 이동한다.
D	Down : 전차가 바라보는 방향을 아래쪽으로 바꾸고, 한 칸 아래의 칸이 평지라면 그 칸으로 이동한다.
L	Left : 전차가 바라보는 방향을 왼쪽으로 바꾸고, 한 칸 왼쪽의 칸이 평지라면 그 칸으로 이동한다.
R	Right : 전차가 바라보는 방향을 오른쪽으로 바꾸고, 한 칸 오른쪽의 칸이 평지라면 그 칸으로 이동한다.
S	Shoot : 전차가 현재 바라보고 있는 방향으로 포탄을 발사한다.

전차가 이동을 하려고 할 때, 만약 게임 맵 밖이라면 전차는 당연히 이동하지 않는다.

전차가 포탄을 발사하면, 포탄은 벽돌로 만들어진 벽 또는 강철로 만들어진 벽에 충돌하거나 게임 맵 밖으로 나갈 때까지 직진한다.

만약 포탄이 벽에 부딪히면 포탄은 소멸하고, 부딪힌 벽이 벽돌로 만들어진 벽이라면 이 벽은 파괴되어 칸은 평지가 된다.

강철로 만들어진 벽에 포탄이 부딪히면 아무 일도 일어나지 않는다.

게임 맵 밖으로 포탄이 나가면 아무런 일도 일어나지 않는다.

초기 게임 맵의 상태와 사용자가 넣을 입력이 순서대로 주어질 때, 모든 입력을 처리하고 나면 게임 맵의 상태가 어떻게 되는지 구하는 프로그램을 작성하라.
#### 🗨 해결방법 :
<br>
이동과 shoot으로 나눔.

- 이동
이동은 초기 맵에서 방향을 먼저 파악.
di, dj로 방향에 따라 이동을 설정.
방향을 바꾼 후, 다음 칸이 평지일 때만 이동.
원래 자리는 평지로 바꿈.

- shoot
이동과 비슷하게 다음 칸을 확인함.
#이 나오면 평지로 바꿈.
*이 나오거나 맵 밖까지 도달한다면 break으로 빠져나옴.
즉, 아무 일도 안 일어남.

#### 📝메모 : 
<br>


<!-- ----- 여기까지 복사 ----- -->
