### PR TITLE
miayujeong / 9월 3주차 / 목

### DIFF
--- a/yujeong/BOJ/boj1261.py
+++ b/yujeong/BOJ/boj1261.py
@@ -1,0 +1,29 @@
+# 1261. 알고스팟
+
+from heapq import heappop, heappush
+
+# 벽 부수는 횟수가 최소인 경로를 탐색하는 함수 dijkstra()
+def dijkstra(x, y):
+    pq = [(0, (x, y))]
+    visited = [[1e9] * M for _ in range(N)]
+    visited[x][y] = 0
+
+    while pq:
+        cnt, (px, py) = heappop(pq)
+        if px==N-1 and py==M-1: # (N, M)에 도착하면
+            return cnt          # 그때까지 벽 부순 횟수 리턴
+        for dx, dy in [(0, 1), (1, 0), (0, -1), (-1, 0)]:
+            nx, ny = px+dx, py+dy
+            if 0<=nx<N and 0<=ny<M:
+                new_cnt = cnt + maze[nx][ny]
+                # 벽 부수는 횟수가 최소인 경우로 갱신
+                if visited[nx][ny] > new_cnt:
+                    visited[nx][ny] = new_cnt
+                    heappush(pq, (visited[nx][ny], (nx, ny)))
+
+
+M, N = map(int, input().split())
+maze = [list(map(int, input())) for _ in range(N)]
+
+ans = dijkstra(0, 0)
+print(ans)

--- a/yujeong/BOJ/boj1987.py
+++ b/yujeong/BOJ/boj1987.py
@@ -1,0 +1,30 @@
+# 1987. 알파벳
+import sys
+input = sys.stdin.readline
+
+
+# 백트래킹으로 보드를 탐색하며 탐색가능한 최대 알파벳 개수를 세는 함수 recur()
+def recur(pos, cnt):
+    global max_c
+    max_c = max(cnt, max_c)
+    if max_c == 26:     # 알파벳 개수 26개보다 많이 탐색할 수 없으므로 가지치기
+        return
+    px, py = pos[0], pos[1]
+    for dx, dy in [(0, 1), (1, 0), (0, -1), (-1, 0)]:
+        nx, ny = px+dx, py+dy
+        if 0<=nx<R and 0<=ny<C:
+            c = board[nx][ny]
+            if c not in visited:    # 아직 지난 적 없는 알파벳이면 그쪽으로 탐색
+                visited.add(c)
+                recur((nx, ny), cnt+1)
+                visited.remove(c)   # 백트래킹
+    return
+
+
+R, C = map(int, input().split())    # 세로 R, 가로 C
+board = [list(input()) for _ in range(R)]
+visited = set(board[0][0])          # 탐색한 알파벳을 set으로 기록
+max_c = 0                           # 탐색가능한 알파벳 최대 개수
+recur((0, 0), 1)
+
+print(max_c)


### PR DESCRIPTION
---

## 🎈boj1261 - 알고스팟

<br>

알고스팟 운영진이 모두 미로에 갇혔다. 미로는 N*M 크기이며, 총 1*1크기의 방 N*M개로 이루어져 있다. 미로는 빈 방 또는 벽으로 이루어져 있고, 빈 방은 자유롭게 다닐 수 있지만, 벽은 부수지 않으면 이동할 수 없다.

어떤 방에서 이동할 수 있는 방은 상하좌우로 인접한 빈 방이다. 즉, 현재 운영진이 (x, y)에 있을 때, 이동할 수 있는 방은 (x+1, y), (x, y+1), (x-1, y), (x, y-1) 이다. 단, 미로의 밖으로 이동 할 수는 없다. 

현재 (1, 1)에 있는 알고스팟 운영진이 (N, M)으로 이동하려면 벽을 최소 몇 개 부수어야 하는지 구하는 프로그램을 작성하시오. 0은 빈 방을 의미하고, 1은 벽을 의미한다. (1, 1)과 (N, M)은 항상 뚫려있다.

<br>

#### 🗨 해결방법 :

벽을 부수는 최소 횟수 = 최소 비용으로 탐색하는 경우를 구해야 하므로 다익스트라

`heapq`로 우선순위 큐를 구현해 탐색하며 벽을 부수는 횟수가 최소가 되도록, 각 지점에 도달하기 위한 최소 비용인 `visited[][]` 배열을 갱신한다.

<br>

#### 📝메모 :

이 문제는 비용이 0 또는 1이기 때문에 BFS로도 해결할 수 있다. 탐색 과정에서 다음 좌표를 큐에 넣을 때 벽이면(비용 있음) 큐 뒤에, 빈 방이면(비용 없음) 큐 앞에 넣으며 처리의 우선순위를 관리할 수 있기 때문이다. 이 과정을 코드로 나타내면 

```python
def bfs(x, y): 
    q = deque([(x, y)]) 
    visited = [[-1] * M for _ in range(N)] 
    visited[x][y] = 0 
    while q: 
        px, py = q.popleft() 
        if px==N-1 and py==M-1: 
            return visited[px][py] 
        for dx, dy in [(0, 1), (1, 0), (0, -1), (-1, 0)]: 
            nx, ny = px+dx, py+dy 
            if 0<=nx<N and 0<=ny<M and visited[nx][ny] == -1: 
                if maze[nx][ny] == 0: 
                    visited[nx][ny] = visited[px][py] 
                    q.appendleft((nx, ny)) 
                else: 
                    visited[nx][ny] = visited[px][py] +1 
                    q.append((nx, ny)) 
    return -1
```

이때 이론적 시간복잡도는 다익스트라가 `O(E logV)`, BFS가 `O(V+E)` 인데 백준에 두 방법 다 채점해서 비교해봤더니 다익스트라가 훨씬 빨랐다. (…)  왜그런지 챗지피티한테 물어봤는데 다음과 같은 의견을 말해줌

> 🔍 **왜 다익스트라가 더 빠를 수 있나?**
> 
> 1. **입력 크기 한계가 작음 (N, M ≤ 100)**
>     - 최대 정점 수 = 10,000
>     - 최대 간선 수 ≈ 40,000
>         
>         → 이 정도 크기에서는 `O(E log V)`와 `O(E)` 차이가 실제 실행시간에 크게 드러나지 않습니다.
>         
> 2. **파이썬 deque의 오버헤드**
>     - `appendleft()` 연산은 `O(1)`이지만, C로 구현된 `heapq`와 비교했을 때 Python 레벨에서의 분기·조건 처리 비용이 상대적으로 더 큽니다.
>     - 특히 `appendleft()`가 자주 호출되면 캐시 효율이 떨어질 수 있습니다.
> 3. **우선순위 큐 구현(heapq)의 효율성**
>     - Python의 `heapq`는 C 구현에 가깝게 최적화되어 있어서 실제 성능이 매우 좋습니다.
>     - 반면 BFS는 `deque` 기반이고, Python 레벨의 조건 분기(`if maze[nx][ny] == 0`)가 많아서 상대적으로 느리게 보일 수 있습니다.
> 4. **테스트 데이터 특성**
>     - 입력 데이터가 랜덤이 아니라 **벽의 분포가 특정 패턴**으로 배치되어 있을 수 있습니다.
>     - 예를 들어 빈 칸이 많다면 `appendleft`가 자주 발생 → 덱의 앞뒤 작업이 잦아져 오히려 손해를 볼 수 있습니다.

<br>

---

## 🎈boj1987 - 알파벳

<br>

세로 R칸, 가로 C칸으로 된 표 모양의 보드가 있다. 보드의 각 칸에는 대문자 알파벳이 하나씩 적혀 있고, 좌측 상단 칸에는 말이 놓여 있다.

말은 상하좌우로 인접한 네 칸 중의 한 칸으로 이동할 수 있는데, 새로 이동한 칸에 적혀 있는 알파벳은 지금까지 지나온 모든 칸에 적혀 있는 알파벳과는 달라야 한다. 즉, 같은 알파벳이 적힌 칸을 두 번 지날 수 없다.

좌측 상단에서 시작해서, 말이 최대한 몇 칸을 지날 수 있는지를 구하는 프로그램을 작성하시오. 말이 지나는 칸은 좌측 상단의 칸도 포함된다.

<br>

#### 🗨 해결방법 :

백트래킹

지금까지 지난 알파벳은 `set`으로 관리하며 지금까지 지난 적 이 없는 알파벳이 있는 칸으로만 이동해 탐색한다.

이동한 횟수가 기존 최대 이동 횟수보다 크면 갱신하는데, 이때 최대 이동 횟수는 알파벳 개수(26개)보다 커질 수 없으므로 가지치기한다.

<br>

#### 📝메모 :

<br>