### PR TITLE
nnnnnara / 9월 3주차 / 목

### DIFF
--- a/nara/BOJ/boj1261.py
+++ b/nara/BOJ/boj1261.py
@@ -1,0 +1,21 @@
+import sys
+from collections import deque
+input = sys.stdin.readline
+
+N, M = map(int, input().split())
+arr = [list(map(int, input().strip())) for _ in range(M)]
+cnt = [[float('inf')] * N for _ in range(M)]
+cnt[0][0] = 0
+q = deque()
+q.append([0, 0])
+while q:
+    state_i, state_j = q.popleft()
+    for di, dj in [[0, -1], [0, 1], [-1, 0], [1, 0]]:
+        ni, nj = state_i + di, state_j + dj
+        if 0 <= ni < M and 0 <= nj < N:
+            tmp = cnt[state_i][state_j] + arr[ni][nj] # arr[ni][nj]가 벽이 있으면 1, 없으면 0
+            if cnt[ni][nj] > tmp:
+                cnt[ni][nj] = tmp
+                q.append([ni, nj])
+
+print(cnt[M-1][N-1])

--- a/nara/BOJ/boj1987.py
+++ b/nara/BOJ/boj1987.py
@@ -1,0 +1,22 @@
+import sys
+sys.setrecursionlimit(10000)
+R, C = map(int, sys.stdin.readline().split())
+arr = [list(sys.stdin.readline().strip()) for _ in range(R)]
+visited_alpha = set()
+max_len = 0
+
+def dfs(pi, pj, count):
+    global max_len
+    max_len = max(max_len, count)
+
+    for di, dj in [[-1, 0], [1, 0], [0, -1], [0, 1]]:
+        ni, nj = pi + di, pj + dj
+        if 0 <= ni < R and 0 <= nj < C:
+            if arr[ni][nj] not in visited_alpha:
+                visited_alpha.add(arr[ni][nj])
+                dfs(ni, nj, count + 1)
+                visited_alpha.remove(arr[ni][nj])
+
+visited_alpha.add(arr[0][0])
+dfs(0, 0, 1)
+print(max_len)


### PR DESCRIPTION
<!-- ----- 여기부터 복사 ----- -->
---
## 🎈BOJ1261 - 알고스팟
### 문제
알고스팟 운영진이 모두 미로에 갇혔다. 미로는 N*M 크기이며, 총 1*1크기의 방으로 이루어져 있다. 미로는 빈 방 또는 벽으로 이루어져 있고, 빈 방은 자유롭게 다닐 수 있지만, 벽은 부수지 않으면 이동할 수 없다.

알고스팟 운영진은 여러명이지만, 항상 모두 같은 방에 있어야 한다. 즉, 여러 명이 다른 방에 있을 수는 없다. 어떤 방에서 이동할 수 있는 방은 상하좌우로 인접한 빈 방이다. 즉, 현재 운영진이 (x, y)에 있을 때, 이동할 수 있는 방은 (x+1, y), (x, y+1), (x-1, y), (x, y-1) 이다. 단, 미로의 밖으로 이동 할 수는 없다.

벽은 평소에는 이동할 수 없지만, 알고스팟의 무기 AOJ를 이용해 벽을 부수어 버릴 수 있다. 벽을 부수면, 빈 방과 동일한 방으로 변한다.

만약 이 문제가 [알고스팟](https://www.algospot.com/)에 있다면, 운영진들은 궁극의 무기 sudo를 이용해 벽을 한 번에 다 없애버릴 수 있지만, 안타깝게도 이 문제는 [Baekjoon Online Judge](https://www.acmicpc.net/)에 수록되어 있기 때문에, sudo를 사용할 수 없다.

현재 (1, 1)에 있는 알고스팟 운영진이 (N, M)으로 이동하려면 벽을 최소 몇 개 부수어야 하는지 구하는 프로그램을 작성하시오.

### 입력
첫째 줄에 미로의 크기를 나타내는 가로 크기 M, 세로 크기 N (1 ≤ N, M ≤ 100)이 주어진다. 다음 N개의 줄에는 미로의 상태를 나타내는 숫자 0과 1이 주어진다. 0은 빈 방을 의미하고, 1은 벽을 의미한다.

(1, 1)과 (N, M)은 항상 뚫려있다.

### 출력
첫째 줄에 알고스팟 운영진이 (N, M)으로 이동하기 위해 벽을 최소 몇 개 부수어야 하는지 출력한다.
#### 🗨 해결방법 :
```
import sys
from collections import deque
input = sys.stdin.readline

N, M = map(int, input().split())
arr = [list(map(int, input().strip())) for _ in range(M)]
cnt = [[float('inf')] * N for _ in range(M)]
cnt[0][0] = 0
q = deque()
q.append([0, 0])
while q:
    state_i, state_j = q.popleft()
    for di, dj in [[0, -1], [0, 1], [-1, 0], [1, 0]]:
        ni, nj = state_i + di, state_j + dj
        if 0 <= ni < M and 0 <= nj < N:
            tmp = cnt[state_i][state_j] + arr[ni][nj] # arr[ni][nj]가 벽이 있으면 1, 없으면 0
            if cnt[ni][nj] > tmp:
                cnt[ni][nj] = tmp
                q.append([ni, nj])

print(cnt[M-1][N-1])
```
칸을 이동하면서 벽일 경우(1일 경우) 바로 값을 더하면서 진행, 최소 값 출력
#### 📝메모 : 


<!-- ----- 여기까지 복사 ----- -->
<!-- ----- 여기부터 복사 ----- -->
---
## 🎈BOJ1987 - 알파벳
### 문제
세로 $R$칸, 가로 $C$칸으로 된 표 모양의 보드가 있다. 보드의 각 칸에는 대문자 알파벳이 하나씩 적혀 있고, 좌측 상단 칸 ($1$행 $1$열) 에는 말이 놓여 있다.

말은 상하좌우로 인접한 네 칸 중의 한 칸으로 이동할 수 있는데, 새로 이동한 칸에 적혀 있는 알파벳은 지금까지 지나온 모든 칸에 적혀 있는 알파벳과는 달라야 한다. 즉, 같은 알파벳이 적힌 칸을 두 번 지날 수 없다.

좌측 상단에서 시작해서, 말이 최대한 몇 칸을 지날 수 있는지를 구하는 프로그램을 작성하시오. 말이 지나는 칸은 좌측 상단의 칸도 포함된다.

### 입력
첫째 줄에 $R$과 $C$가 빈칸을 사이에 두고 주어진다. ($1 ≤ R,C ≤ 20$) 둘째 줄부터 $R$개의 줄에 걸쳐서 보드에 적혀 있는 $C$개의 대문자 알파벳들이 빈칸 없이 주어진다.

### 출력
첫째 줄에 말이 지날 수 있는 최대의 칸 수를 출력한다.
#### 🗨 해결방법 :
```
import sys
sys.setrecursionlimit(10000)
R, C = map(int, sys.stdin.readline().split())
arr = [list(sys.stdin.readline().strip()) for _ in range(R)]

visited_alpha = set()
max_len = 0

def dfs(pi, pj, count):
    global max_len
    max_len = max(max_len, count)

    for di, dj in [[-1, 0], [1, 0], [0, -1], [0, 1]]:
        ni, nj = pi + di, pj + dj
        if 0 <= ni < R and 0 <= nj < C:
            if arr[ni][nj] not in visited_alpha:
                visited_alpha.add(arr[ni][nj])
                dfs(ni, nj, count + 1)
                visited_alpha.remove(arr[ni][nj])

visited_alpha.add(arr[0][0])
dfs(0, 0, 1)
print(max_len)
```
DFS를 사용하여 해결
visited_alpha를 set으로 선언하였는데, list보다 연산이 빠르고 알파벳을 한 번씩만 저장하면 되기에 중복이 없어도 상관 없기에 선택하였다.
add와  append는 비슷하다 생각했지만 list에서 pop은 가장 앞, 뒤 값만 제거할 수 있는 반면 set에서 remove는 특정 값을 제거할 수 있어 편리했다. 
#### 📝메모 : 
처음엔 더 익숙한 BFS로 해결하였는데 결과는 출력되었으나 Python3 에서는 시간 초과가, Pypy에서는 메모리 초과가 나왔다.
따라서 DFS를 사용하였다.
아래는 BFS 코드 ㅠㅡㅠ
```
import sys
input = sys.stdin.readline
from collections import deque

R, C = map(int, input().split())
graph = [list(input().strip()) for _ in range(R)]
q = deque()
q.append([0, 0, graph[0][0], 1]) # 시작점
max_len = 1
while q:
    pi, pj, path, length = q.popleft()
    max_len = max(max_len, length)
    for di, dj in [[-1, 0], [1, 0], [0, -1], [0, 1]]:
        ni, nj = pi + di, pj + dj
        if 0 <= ni < R and 0 <= nj < C:
            next_alpha = graph[ni][nj]
            if next_alpha not in path:
                q.append([ni, nj, path + next_alpha, length + 1])

print(max_len)
```
<!-- ----- 여기까지 복사 ----- -->