### PR TITLE
valofosho / 9월 3주차 / 목

### DIFF
--- a/valofosho/BOJ/boj1261.py
+++ b/valofosho/BOJ/boj1261.py
@@ -1,0 +1,83 @@
+"""
+BOJ1261-알고스팟
+움직일 수 있는 방향은 좌우상하
+지나가면서 0이면 지나가고 1이면 벽뚫기
+그러니까 가는데 간선의 비용이 1인거임
+"""
+# 1번 BFS 활용 버전 - 136ms
+import sys
+input = sys.stdin.readline
+def check(i,j):
+    if 0<=i<N and 0<=j<M:
+        return True
+    else:
+        return False
+
+
+def bfs(si,sj):
+    q = deque([])
+    q.append((si,sj))
+    visited[si][sj] = 0
+    di = [1, 0, -1, 0]
+    dj = [0, 1, 0, -1]
+    while q:
+        i, j = q.popleft()
+        for d in range(4):
+            ni, nj = i+di[d], j+dj[d]
+            # i,j -> 출발위치
+            # ni, nj -> 도착 위치
+            # if 도착위치 > 길찾기
+            if check(ni,nj):
+                temp = visited[i][j] + maps[ni][nj]
+                if temp < visited[ni][nj]:
+                    visited[ni][nj] = temp
+                    q.append((ni,nj))
+    return visited[N-1][M-1]
+
+from collections import deque
+M, N = map(int, input().split())
+maps = [list(map(int, input().rstrip())) for _ in range(N)]
+INF = float('inf')
+visited = [[INF] * M for _ in range(N)]
+ans = bfs(0,0)
+print(ans)
+
+
+# 2번 다익스트라 활용 버전 - 188ms
+import heapq
+import sys
+
+input = sys.stdin.readline
+
+def check(i,j):
+    if 0<=i<N and 0<=j<M:
+        return True
+    else:
+        return False
+
+def dijkstra(si, sj):
+    pq = [(0,(si,sj))]
+    INF = float('inf')
+    visited = [[INF] * M for _ in range(N)]
+    visited[si][sj] = 0
+
+    while pq:
+        cnt, (i, j) = heapq.heappop(pq)
+        if i == N-1 and j == M-1:
+            return cnt       
+        for d in range(4):
+            ni, nj = i+di[d], j+dj[d]
+            if check(ni,nj):
+                temp = cnt + maps[ni][nj]
+                # 벽 부수는 횟수가 최소인 경우로 갱신
+                if visited[ni][nj] > temp:
+                    visited[ni][nj] = temp
+                    heapq.heappush(pq, (visited[ni][nj], (ni, nj)))
+
+
+M, N = map(int, input().split())
+maps = [list(map(int,input().strip())) for _ in range(N)]
+di = [1, 0, -1, 0]
+dj = [0, 1, 0, -1]
+ans = dijkstra(0, 0)
+print(ans)

--- a/valofosho/BOJ/boj1987.py
+++ b/valofosho/BOJ/boj1987.py
@@ -1,0 +1,71 @@
+"""
+상하좌우 인접 칸 이동
+새로 이동한 칸에 적힌 알파벳은 모든 칸에 있던 애랑 달라야 한다
+말이 갈 수 있는 최대한의 수
+시작 자리 문자열에 + 로 가는 곳 문자열 더하기
+cnt를 1부터 dfs돌리면서 최대값 찾기 만약 len(str) 과 cnt가 다르면 break
+
+"""
+# 최초 제출 버전 (DFS + 문자열 사용) - 6100ms
+import sys
+input = sys.stdin.readline
+
+def check(i,j):
+    if 0<=i<R and 0<=j<C:
+        return True
+    else:
+        return False
+
+
+def dfs(i, j, cnt, string):
+    global answer
+    if cnt > answer:
+        answer = cnt
+    
+    visited[i][j] = True
+    for d in range(4):
+        ni,nj = i+di[d], j+dj[d]
+        if check(ni,nj) and maps[ni][nj] not in string:
+            if not visited[ni][nj]:
+                visited[ni][nj] = True
+                dfs(ni,nj,cnt+1, string + maps[ni][nj])
+    visited[i][j] = False
+
+R, C = map(int, input().split())
+maps = [list(input().strip()) for _ in range(R)]
+di = [1, 0, -1, 0]
+dj = [0, 1, 0, -1]
+
+visited = [[False] * C for _ in range(R)]
+answer = 0
+dfs(0,0,1,maps[0][0])
+print(answer)
+
+# 2번 풀이 (DFS + set 활용) - 6472ms
+import sys
+input = sys.stdin.readline
+
+def check(i,j):
+    return 0<=i<R and 0<=j<C
+
+def dfs(i, j, cnt, string):
+    global answer
+    answer = max(answer, cnt)
+    if answer == 26:
+        return
+
+    for d in range(4):
+        ni, nj = i+di[d], j+dj[d]
+        if check(ni,nj) and maps[ni][nj] not in string:
+            string.add(maps[ni][nj])
+            dfs(ni,nj,cnt+1,string)
+            string.remove(maps[ni][nj])  # 백트래킹
+
+R, C = map(int, input().split())
+maps = [list(input().strip()) for _ in range(R)]
+di = [1, 0, -1, 0]
+dj = [0, 1, 0, -1]
+
+answer = 0
+dfs(0,0,1,set(maps[0][0]))
+print(answer)


### PR DESCRIPTION
<!-- ----- 여기부터 복사 ----- -->
---
## 🎈BOJ1261 - 알고스팟
문제
알고스팟 운영진이 모두 미로에 갇혔다. 미로는 N*M 크기이며, 총 1*1크기의 방으로 이루어져 있다. 미로는 빈 방 또는 벽으로 이루어져 있고, 빈 방은 자유롭게 다닐 수 있지만, 벽은 부수지 않으면 이동할 수 없다.

알고스팟 운영진은 여러명이지만, 항상 모두 같은 방에 있어야 한다. 즉, 여러 명이 다른 방에 있을 수는 없다. 어떤 방에서 이동할 수 있는 방은 상하좌우로 인접한 빈 방이다. 즉, 현재 운영진이 (x, y)에 있을 때, 이동할 수 있는 방은 (x+1, y), (x, y+1), (x-1, y), (x, y-1) 이다. 단, 미로의 밖으로 이동 할 수는 없다.

벽은 평소에는 이동할 수 없지만, 알고스팟의 무기 AOJ를 이용해 벽을 부수어 버릴 수 있다. 벽을 부수면, 빈 방과 동일한 방으로 변한다.

만약 이 문제가 알고스팟에 있다면, 운영진들은 궁극의 무기 sudo를 이용해 벽을 한 번에 다 없애버릴 수 있지만, 안타깝게도 이 문제는 Baekjoon Online Judge에 수록되어 있기 때문에, sudo를 사용할 수 없다.

현재 (1, 1)에 있는 알고스팟 운영진이 (N, M)으로 이동하려면 벽을 최소 몇 개 부수어야 하는지 구하는 프로그램을 작성하시오.

입력
첫째 줄에 미로의 크기를 나타내는 가로 크기 M, 세로 크기 N (1 ≤ N, M ≤ 100)이 주어진다. 다음 N개의 줄에는 미로의 상태를 나타내는 숫자 0과 1이 주어진다. 0은 빈 방을 의미하고, 1은 벽을 의미한다.

(1, 1)과 (N, M)은 항상 뚫려있다.

출력
첫째 줄에 알고스팟 운영진이 (N, M)으로 이동하기 위해 벽을 최소 몇 개 부수어야 하는지 출력한다.
<br>

#### 🗨 해결방법 :
문제를 보고 두 가지 풀이 방법을 생각했다
1. BFS를 활용한 풀이
2. 다익스트라를 활용한 풀이
우선 BFS를 활용하는 방법은 기존 방법에서 이전까지 거리 + 맵의 1 or 0을 합친게 기존 visited보다 작으면 재할당하는 형식을 활용했다.
다익스트라를 활용한 풀이는 2차원배열 다익스트라를 활용해 heapq에서 maps[N-1][M-1]에 도착하면 return하는 방식을 활용했다.
<br>


#### 📝메모 : 
물론 변수 할당이나 리스트 접근, 함수 활용에 따라 조금씩 시간차이가 날 수 있는데
BFS가 다익스트라 방식에 비해 시간복잡도가 더 적게 걸린 부분은 신기했다.
문제에 들어있는 테스트케이스와 배열의 크기 등 다양한 요인이 걸리는데 이 부분은 다른 풀이들도 참고하면서 비교해볼 예정이다.
<br>

<!-- ----- 여기까지 복사 ----- -->
<!-- ----- 여기부터 복사 ----- -->
---
## 🎈BOJ 1987 - 알파벳
문제
세로 
$R$칸, 가로 
$C$칸으로 된 표 모양의 보드가 있다. 보드의 각 칸에는 대문자 알파벳이 하나씩 적혀 있고, 좌측 상단 칸 (
$1$행 
$1$열) 에는 말이 놓여 있다.

말은 상하좌우로 인접한 네 칸 중의 한 칸으로 이동할 수 있는데, 새로 이동한 칸에 적혀 있는 알파벳은 지금까지 지나온 모든 칸에 적혀 있는 알파벳과는 달라야 한다. 즉, 같은 알파벳이 적힌 칸을 두 번 지날 수 없다.

좌측 상단에서 시작해서, 말이 최대한 몇 칸을 지날 수 있는지를 구하는 프로그램을 작성하시오. 말이 지나는 칸은 좌측 상단의 칸도 포함된다.

입력
첫째 줄에 R과 C가 빈칸을 사이에 두고 주어진다. (1 ≤ R,C ≤ 20) 둘째 줄부터 R개의 줄에 걸쳐서 보드에 적혀 있는 C개의 대문자 알파벳들이 빈칸 없이 주어진다.

출력
첫째 줄에 말이 지날 수 있는 최대의 칸 수를 출력한다.
<br>

#### 🗨 해결방법 :
1. DFS + 문자열 활용
  - 시간 복잡도를 최대한 고려해서 재귀횟수 cnt와 문자열을 DFS에 함께 넣고 돌려준다.
  - 문자열과 cnt의 길이가 다르면 return하는 형식으로 구현
2. DFS + set 활용
  - 마찬가지로 set로 선언한 뒤 visited 배열을 활용하지 않고 set를 대신 활용하는 느낌으로 진행
  - visited가 없어도 되는 이유는 이미 갔던 부분으로 돌아가면 set와 cnt의 차이가 발생하기 때문(중복값이니까!) 
<br>


#### 📝메모 : 
시간복잡도 측면에서 최대한 `in`을 활용하지 않으려고 고려해봤다
다만 `set`를 활용하면 결국 `len(set)` 으로 길이 비교가 필요해서 이 부분이 아직도 해결되지 않았다.
비트마스킹 같은 방법론도 활용해서 한 번 고민해봐야겠다.
다른 사람 풀이를 보고 answer == 26에서의 pruning을 알고 소름이 끼쳤는데 그렇게까지 큰 시간 차이는 없었다고 한다.
<br>

<!-- ----- 여기까지 복사 ----- -->
