### PR TITLE
aeongseo / 9월 3주차 / 목

### DIFF
--- a/aeongseo/BOJ/CPP/boj1261.cpp
+++ b/aeongseo/BOJ/CPP/boj1261.cpp
@@ -1,0 +1,89 @@
+/*** 1261. 알고스팟 ***/
+
+#include<iostream>
+#include<vector>
+#include<queue>
+#include<string>
+#include<climits>	// 무한대 값 INT_MAX 사용을 위한 라이브러리
+using namespace std;
+
+int dijkstra(int si, int sj);
+
+vector<vector<int>> maze;
+vector<vector<int>> dists;	// 벽을 부순 횟수의 최소값 찾기 위한 배열
+int M, N;
+int di[4] = { 0, 1, 0, -1 };
+int dj[4] = { 1, 0, -1, 0 };
+
+int main() {
+	cin >> M >> N;
+	maze.assign(N, vector<int>(M));
+	dists.assign(N, vector<int>(M, INT_MAX));
+
+	for (int i = 0; i < N; i++) {
+		string line;
+		cin >> line;
+		for (int j = 0; j < M; j++) {
+			maze[i][j] = line[j] - '0';
+		}
+	}
+
+	int result = dijkstra(0, 0);	// 시작 지점에서 다익스트라 시작
+	cout << result;
+
+	return 0;
+}
+
+int dijkstra(int si, int sj) {
+	priority_queue<pair<int, pair<int, int>>, vector<pair<int, pair<int, int>>>, greater<pair<int, pair<int, int>>>> pq;
+	pq.push({ 0, { si, sj } }); // {가중치, {x좌표, y좌표}}
+	dists[si][sj] = 0;
+
+
+	while(!pq.empty()) {
+		int dist = pq.top().first;
+		int ti = pq.top().second.first;
+		int tj = pq.top().second.second;
+		pq.pop();
+
+		if (dists[ti][tj] < dist) continue;
+
+		for (int i = 0; i < 4; i++) {
+			int ni = ti + di[i];
+			int nj = tj + dj[i];
+
+			if (ni < 0 || ni >= N || nj < 0 || nj >= M) continue;
+
+			int new_dist = dist;	// 기본값으로 빈방이라고 생각하고 경로값 유지
+			if (maze[ni][nj]) new_dist++;	// 해당 위치가 벽이면 가중치 1 을 더함
+			if (dists[ni][nj] <= new_dist) continue;
+
+			dists[ni][nj] = new_dist;
+			pq.push({ new_dist, {ni, nj} });
+		}
+	}
+
+	return dists[N - 1][M - 1];	// 종료 지점의 최단 거리 반환
+}
+
+
+/* (21줄)
+ limits라이브러리의 INFINITY는 float형이다. climits 라이브러리의 INT_MAX가 int형이다.
+*/
+
+/* (23~29줄)
+ 공백없는 입력을 cin >> maze[i][j]로 받았더니 각각의 요소로 입력이 들어가지 않고, 통째로 들어갔다.
+ string으로 한줄을 한번에 입력받고 각 배열에 요소를 int형으로 변환하여 저장했다. 그러나 아스키코드가 숫자로만 바뀌어 0이 48로 저장되었다.
+ 0과 1을 저장하기 위해 아스키코드 '0'을 빼서 정수로 저장하였다.
+*/
+
+/* (38줄)
+ 가중치와 좌표를 넣어야 하므로 우선순위 큐에 3개의 요소를 넣기 위해 tuple로 선언하였다.
+ 그러나 tuple은 가중치와 좌표가 다 정렬의 키로 사용된다.
+ 가중치만 키로 사용해야 하기 때문에 요소 좌표를 포함하여 요소 3개를 받아야 한다면 pair를 중첩하여 사용하도록 하자!
+*/
+
+/* (47줄)
+ pq.pop()을 넣지 않아 무한 루프에 빠졌다.
+ 코드를 암기하려고 하지 말고 알고리즘을 떠올리면서 작성하자...
+*/

--- a/aeongseo/BOJ/CPP/boj1987.cpp
+++ b/aeongseo/BOJ/CPP/boj1987.cpp
@@ -1,0 +1,62 @@
+/*** 1987. 알파벳 ***/
+
+#include<iostream>
+#include<vector>
+#include<string>
+#include<set>
+#include<algorithm>
+using namespace std;
+
+void backtrack(int si, int sj, int cnt);
+
+vector<vector<char>> arr;
+bool alphabet[26] = { false };
+int di[4] = { 0, 1, 0, -1 };
+int dj[4] = { 1, 0, -1, 0 };
+int R, C;
+int max_cnt = 0;
+
+int main() {
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+
+	cin >> R >> C;
+
+	arr.assign(R, vector<char>(C));
+
+	for (int i = 0; i < R; i++) {
+		string line;
+		cin >> line;
+		for (int j = 0; j < C; j++) {
+			arr[i][j] = line[j];
+		}
+	}
+	// 공백이 없으므로 한줄 입력 받고 각 배열 요소에 집어넣는다.
+
+	alphabet[arr[0][0] - 'A'] = true;
+	backtrack(0, 0, 1); // 시작지점부터 카운트하기 때문에 1부터 시작
+
+	cout << max_cnt;
+	return 0;
+}
+
+void backtrack(int si, int sj, int cnt) {
+	max_cnt = max(max_cnt, cnt);
+
+	for (int i = 0; i < 4; i++) {
+		int ni = si + di[i];
+		int nj = sj + dj[i];
+
+		if (ni < 0 || ni >= R || nj < 0 || nj >= C) {
+			continue;
+		}
+		if (alphabet[arr[ni][nj]-'A']) {
+			continue;
+		}
+
+		alphabet[arr[ni][nj]-'A'] = true;
+		backtrack(ni, nj, cnt + 1);
+		alphabet[arr[ni][nj] - 'A'] = false;
+	}
+
+}


### PR DESCRIPTION
---
## 🎈boj 1261 알고스팟
<br>

알고스팟 운영진이 모두 미로에 갇혔다. 미로는 N*M 크기이며, 총 1*1크기의 방으로 이루어져 있다. 미로는 빈 방 또는 벽으로 이루어져 있고, 빈 방은 자유롭게 다닐 수 있지만, 벽은 부수지 않으면 이동할 수 없다.

알고스팟 운영진은 여러명이지만, 항상 모두 같은 방에 있어야 한다. 즉, 여러 명이 다른 방에 있을 수는 없다. 어떤 방에서 이동할 수 있는 방은 상하좌우로 인접한 빈 방이다. 즉, 현재 운영진이 (x, y)에 있을 때, 이동할 수 있는 방은 (x+1, y), (x, y+1), (x-1, y), (x, y-1) 이다. 단, 미로의 밖으로 이동 할 수는 없다.

벽은 평소에는 이동할 수 없지만, 알고스팟의 무기 AOJ를 이용해 벽을 부수어 버릴 수 있다. 벽을 부수면, 빈 방과 동일한 방으로 변한다.

만약 이 문제가 알고스팟에 있다면, 운영진들은 궁극의 무기 sudo를 이용해 벽을 한 번에 다 없애버릴 수 있지만, 안타깝게도 이 문제는 Baekjoon Online Judge에 수록되어 있기 때문에, sudo를 사용할 수 없다.

현재 (1, 1)에 있는 알고스팟 운영진이 (N, M)으로 이동하려면 벽을 최소 몇 개 부수어야 하는지 구하는 프로그램을 작성하시오.

[입력]

첫째 줄에 미로의 크기를 나타내는 가로 크기 M, 세로 크기 N (1 ≤ N, M ≤ 100)이 주어진다. 다음 N개의 줄에는 미로의 상태를 나타내는 숫자 0과 1이 주어진다. 0은 빈 방을 의미하고, 1은 벽을 의미한다.

(1, 1)과 (N, M)은 항상 뚫려있다.

[출력]

첫째 줄에 알고스팟 운영진이 (N, M)으로 이동하기 위해 벽을 최소 몇 개 부수어야 하는지 출력한다.

#### 🗨 해결방법 :
<br>

- 다익스트라를 이용하였다.
    - 벽을 부수는 것을 가중치로 설정하여, 맵의 요소가 0이면 가중치 0, 1이면 가중치 1을 설정하였다.
    - 다익스트라를 통해 가중치가 가장 작은 경로가 벽을 가장 적게 부수는 경로이다.
    - (1, 1)(코드에서는 (0, 0))에서 다익스트라를 수행하여 도착지점인 (N, M) (코드에서는 (N-1, M-1))의 경로 값을 출력한다.

#### 📝메모 : 
<br>

- limits라이브러리의 INFINITY는 float형이다. climits 라이브러리의 INT_MAX가 int형이다.
- 공백없는 입력을 cin >> maze[i][j]로 받았더니 각각의 요소로 입력이 들어가지 않고, 통째로 들어갔다.
    - string으로 한줄을 한번에 입력받고 각 배열에 요소를 int형으로 변환하여 저장했다. 그러나 아스키코드가 숫자로만 바뀌어 0이 48로 저장되었다.
    - 0과 1을 저장하기 위해 아스키코드 '0'을 빼서 정수로 저장하였다.
- 가중치와 좌표를 넣어야 하므로 우선순위 큐에 3개의 요소를 넣기 위해 tuple로 선언하였다.
    - 그러나 tuple은 가중치와 좌표가 다 정렬의 키로 사용된다.
    - 가중치만 키로 사용해야 하기 때문에 요소 좌표를 포함하여 요소 3개를 받아야 한다면 pair를 중첩하여 사용하도록 하자!
- pq.pop()을 넣지 않아 무한 루프에 빠졌다.
    - 코드를 암기하려고 하지 말고 알고리즘을 떠올리면서 작성하자...

---
## 🎈boj 1987 알파벳
<br>

세로 R칸, 가로 C칸으로 된 표 모양의 보드가 있다. 보드의 각 칸에는 대문자 알파벳이 하나씩 적혀 있고, 좌측 상단 칸 (1행 1열) 에는 말이 놓여 있다.

말은 상하좌우로 인접한 네 칸 중의 한 칸으로 이동할 수 있는데, 새로 이동한 칸에 적혀 있는 알파벳은 지금까지 지나온 모든 칸에 적혀 있는 알파벳과는 달라야 한다. 즉, 같은 알파벳이 적힌 칸을 두 번 지날 수 없다.

좌측 상단에서 시작해서, 말이 최대한 몇 칸을 지날 수 있는지를 구하는 프로그램을 작성하시오. 말이 지나는 칸은 좌측 상단의 칸도 포함된다.

[입력]

첫째 줄에 R과 C가 빈칸을 사이에 두고 주어진다. (1 ≤ R,C ≤ 20) 둘째 줄부터 R개의 줄에 걸쳐서 보드에 적혀 있는 C개의 대문자 알파벳들이 빈칸 없이 주어진다.

[출력]

첫째 줄에 말이 지날 수 있는 최대의 칸 수를 출력한다.

#### 🗨 해결방법 :
<br>

- 백트래킹을 사용하였다.
- 지나간 알파벳을 체크하기 위해 bool 배열을 선언하였다. 인덱스는 arr[i][j]에서 ‘A’를 뺀 값으로 A=0 ~ Z=25 의 인덱스를 사용하였다.

#### 📝메모 : 
<br>

- set을 사용했을 때 시간초과가 발생했다.
    - 알파벳을 사용했는지 bool을 사용하여 체크한다.
    - set은 $O(logn)$, bool 배열은 $O(1)$이다.
- flag를 통해 더이상 움직일 수 없으면 최대값을 갱신하도록 하였는데, flag를 전역변수로 선언하여 코드가 꼬였다. 오히려 없어도 코드가 잘 돌아갔다.
