### PR TITLE
codingdarin / 9월 3주차 / 목

### DIFF
--- a/codingdarin/BOJ/boj1261.py
+++ b/codingdarin/BOJ/boj1261.py
@@ -1,0 +1,39 @@
+import heapq
+import sys
+
+input = lambda: sys.stdin.readline().rstrip()
+
+M, N = map(int, input().split())
+maze = [input() for _ in range(N)]
+
+# 다익스트라로 최단경로 찾기
+dist = [[float('inf')] * M for _ in range(N)]  # 거리 배열
+dist[0][0] = 0
+pq = [(0, 0, 0)]  # (비용, x, y)
+
+# 델타 배열
+dx = [0,1,0,-1]
+dy = [1,0,-1,0]
+
+while pq:
+    cost, x, y = heapq.heappop(pq)
+    
+    # 목표 도달시 종료
+    if x == N-1 and y == M-1:
+        print(cost)
+        break
+    
+    # 이미 더 짧은 경로가 있으면 스킵
+    if dist[x][y] < cost:
+        continue
+    
+    # 4방향 탐색
+    for i in range(4):
+        nx, ny = x + dx[i], y + dy[i]
+        
+        if 0 <= nx < N and 0 <= ny < M:
+            new_cost = cost + int(maze[nx][ny])  # 벽이면 +1, 빈방이면 +0
+            
+            if new_cost < dist[nx][ny]:
+                dist[nx][ny] = new_cost
+                heapq.heappush(pq, (new_cost, nx, ny))

--- a/codingdarin/BOJ/boj1987.py
+++ b/codingdarin/BOJ/boj1987.py
@@ -1,0 +1,113 @@
+# BOJ 1987 . 알파벳 (D3 /G4)
+
+#------------------------3회차: 백준 정답코드 참고
+import sys
+
+input = lambda: sys.stdin.readline().rstrip()
+
+r, c = map(int, input().split())
+graph = [input() for _ in range(r)]
+
+#델타 배열
+dx = [0,1,0,-1]
+dy = [1,0,-1,0] 
+
+for _ in range(r):
+    graph.append(list(sys.stdin.readline().strip()))
+
+def dfs(sx,sy):
+    q = set()
+    q.add((sx,sy,graph[sx][sy]))
+    squares = 0
+
+    while q:
+        x, y, now_visited = q.pop()
+
+        squares = max(squares, len(now_visited))
+        if squares == 26:
+            return 26
+        for i in range(4):
+            nx = x + dx[i]
+            ny = y + dy[i]
+
+            if (0 <= nx < r) and (0 <= ny < c) and graph[nx][ny] not in now_visited:
+                q.add((nx, ny, now_visited + graph[nx][ny]))
+    return squares
+print(dfs(0,0))
+
+
+
+# #------------------------2회차 풀이: pypy만 통과
+
+# input = lambda: sys.stdin.readline().rstrip()
+
+# R, C = map(int, input().split())
+# arr = [input() for _ in range(R)]
+
+# #델타 배열
+# di = [0,1,0,-1]
+# dj = [1,0,-1,0] 
+
+# max_length = 0
+# visited = [False] * 26  # A~Z용
+
+# def dfs(i, j, visited_bits, length):
+#     global max_length
+    
+#     bit = 1 << (ord(arr[i][j]) - ord('A'))  # 비트 위치
+#     if visited_bits & bit:  # 이미 방문했나?
+#         return
+    
+#     visited_bits |= bit  # 방문 표시
+#     max_length = max(max_length, length)
+    
+#     for k in range(4):
+#         ni, nj = i + di[k], j + dj[k]
+#         if 0 <= ni < R and 0 <= nj < C:
+#             dfs(ni, nj, visited_bits, length + 1)
+    
+#     # 백트래킹 (visited_bits는 값 복사라 자동으로 복구됨)
+
+# dfs(0, 0, 0, 1)
+
+# print(max_length)
+
+
+
+# #------------------------1회차 풀이: pypy만 통과
+# import sys
+
+# input = lambda: sys.stdin.readline().rstrip()
+
+# R, C = map(int, input().split())
+# arr = [input() for _ in range(R)]
+
+# #델타 배열
+# di = [0,1,0,-1]
+# dj = [1,0,-1,0] 
+
+# max_length = 0
+
+# def dfs(i, j, path):
+#     global max_length
+#     # 일단 현재 위치 처리
+#     cur_c = arr[i][j]
+#     if cur_c in path:
+#         return
+    
+#     temp = path
+#     path += cur_c
+#     max_length = max(max_length, len(path))
+    
+#     # 재귀 시동
+#     for xi, xj in zip(di,dj):
+#         ni, nj = i+xi, j+xj
+#         if 0 <= ni < R and 0<= nj < C:
+#             dfs(ni, nj, path)
+    
+#     #백트래킹
+#     path = temp
+        
+    
+# dfs(0, 0, '') #현재위치, txt
+# print(max_length)


### PR DESCRIPTION
<!-- ----- 여기부터 복사 ----- -->
---
## 🎈BOJ 1987 - 알파벳
<br>
(0,0)에서 시작해서 상하좌우로 이동하며 같은 알파벳을 밟지 않고 최대한 많이 이동하기 

입력: R×C 보드와 각 칸의 알파벳 / 출력: 지날 수 있는 최대 칸 수
<br>

#### 🗨 해결방법 :

DFS + 백트래킹 (스택 구현)

* 상태를 (x, y, 방문한알파벳들) 튜플로 set에 저장
* set.pop()으로 스택처럼 동작하며 DFS 탐색
* 같은 알파벳 재방문 불가 조건 체크
* 조기 종료: 알파벳 26개 모두 방문시 바로 리턴

<br>

#### 📝메모 :

* 처음엔 재귀로 했다가 시간초과 → 스택 기반 반복문으로 해결
* 문자열 연산 `now_visited + graph[nx][ny]`로 새 상태 생성
* 재귀보다 반복문이 더 빠른 문제에서 굳이굳이 재귀를 여러 방면으로 시도

<br>
<!-- ----- 여기까지 복사 ----- -->

<!-- ----- 여기부터 복사 ----- -->
---
## 🎈BOJ 1261 - 알고스팟
<br>
미로의 (0,0)에서 (N-1,M-1)까지 가는데 벽을 최소한으로 부수며 이동하기 

입력: 가로M, 세로N, 미로 정보 (0은 빈방, 1은 벽) / 출력: 부셔야 하는 벽의 최소 개수
<br>

#### 🗨 해결방법 :

다익스트라 (가중치 있는 최단경로)

* 빈 방(0) 이동: 비용 0
* 벽(1) 부수고 이동: 비용 1
* heapq로 우선순위 큐 구현, (비용, x, y) 형태로 저장
* dist 배열로 최소 비용 갱신 및 중복 방지

<br>

#### 📝메모 :

* 단순 BFS가 아닌 가중치 고려한 다익스트라 필요
* `new_cost = cost + int(maze[nx][ny])` 핵심 로직
* 목표 지점 도달시 바로 출력하고 break
* `dist[x][y] < cost` 조건으로 이미 더 좋은 경로 있으면 스킵
* 0 1 BFS라는 방법도 있다고 함 (아직 공부하지 않아서 다음에 해봐야겠다)

<br>
<!-- ----- 여기까지 복사 ----- -->