### PR TITLE
aeongseo / 9월 4주차 / 화

### DIFF
--- a/aeongseo/BOJ/CPP/boj1707.cpp
+++ b/aeongseo/BOJ/CPP/boj1707.cpp
@@ -1,0 +1,76 @@
+/*** 1707. 이분 그래프 ***/
+
+#include<iostream>
+#include<vector>
+#include<queue>
+using namespace std;
+
+void bfs(int start);
+
+vector<vector<int>> graph;
+vector<bool> visited;
+vector<int> check;
+bool flag = true;	// 이분 그래프 판별을 위한 플래그
+
+int main() {
+	int K;
+	cin >> K;
+	for (int tc = 1; tc < K + 1; tc++) {
+		int V, E, start;
+		cin >> V >> E;
+
+		// 테스트케이스 새로 실행될 때마다 크기 재정의, 초기화
+		graph.clear();
+		graph.resize(V + 1);
+		visited.assign(V + 1, false);
+		check.assign(V + 1, 0);
+
+		for (int i = 0; i < E; i++) {
+			int u, v;
+			cin >> u >> v;
+			if (i == 0) start = u;
+			graph[u].push_back(v);	// 양방향으로 인접리스트 저장
+			graph[v].push_back(u);
+		}
+
+		for (int j = 1; j < V + 1; j++) {
+			if (!visited[j]) bfs(j);	// 방문한 기록이 없으면 bfs 수행
+			if (!flag) break;
+		}
+		if (flag) cout << "YES" << '\n';
+		else cout << "NO" << '\n';
+		flag = true;    // 다음 테스트 케이스에서 플래스 사용을 위해 초기화
+	}
+
+
+	return 0;
+}
+
+void bfs(int start) {
+	queue<int> q;
+	q.push(start);
+	visited[start] = true;
+	check[start] = 1;
+
+	while (!q.empty()) {
+		int t = q.front();
+		q.pop();
+		
+		for (const auto& n : graph[t]) {
+			// 인접 정점을 방문한 적 없으면 현재 정점과 다른 숫자 저장
+			if (!visited[n]) {
+				visited[n] = true;
+				q.push(n);
+				if (check[t] == 1) check[n] = 2;
+				else check[n] = 1;
+			}
+			// 모두 방문했는데 색이 같으면 이분 그래프 아님
+			else if (visited[t] && visited[n]) {
+				if (check[t] == check[n]) {
+					flag = false;
+					return;
+				}
+			}
+		}
+	}
+}

--- a/aeongseo/BOJ/CPP/boj1759.cpp
+++ b/aeongseo/BOJ/CPP/boj1759.cpp
@@ -1,0 +1,52 @@
+/*** 1759. 암호 만들기 ***/
+#include<iostream>
+#include<vector>
+#include<algorithm>
+using namespace std;
+
+void backtrack(int idx, int cnt, int vowel, int consonant);	// idx: 현재 인덱스, cnt: 암호로 선택한 문자 개수, vowel: 암호의 모음 개수, consonant: 암호의 자음 개수
+
+vector<char> characters;
+vector<char> pw;
+char vowel_arr[5] = { 'a', 'e', 'i', 'o', 'u' };	// 모음 배열
+int L, C;
+
+int main() {
+	cin >> L >> C;
+
+	characters.resize(C);
+	for (int i = 0; i < C; i++) {
+		cin >> characters[i];
+	}
+	sort(characters.begin(), characters.end());	// 문자 오름차순으로 정렬
+	
+	backtrack(0, 0, 0, 0);
+
+	return 0;
+}
+
+void backtrack(int idx, int cnt, int vowel, int consonant) {
+	if (cnt == L) {	// L개를 조합했을 때
+		if (vowel >= 1 && consonant >= 2) {	// 모음 1개 이상, 자음 2개 이상이면 출력
+			for (int i = 0; i < L; i++) {
+				cout << pw[i];
+			}
+			cout << '\n';
+		}
+		return;
+	}
+
+	if (idx == C) return;	// C번 문자까지 다 돌면 반환
+	
+	pw.push_back(characters[idx]);	// pw에 문자 저장
+	bool flag = false;	// 모음 판단을 위한 플래그
+	for (int j = 0; j < 5; j++) {
+		if (characters[idx] == vowel_arr[j]) {	// 현재 문자가 모음 리스트에 있으면 플래그 true
+			flag = true;
+		}
+	}
+	if (flag) backtrack(idx + 1, cnt + 1, vowel + 1, consonant); // 플래그가 true면 모음개수 증가하고 재귀 진행
+	else backtrack(idx + 1, cnt + 1, vowel, consonant + 1);	// false면 자음개수 증가하고 재귀 진행
+	pw.pop_back();	// pw에 문자 제거
+	backtrack(idx + 1, cnt, vowel, consonant);	// 현재 문자를 선택하지 않고 재귀 진행
+}

--- a/aeongseo/BOJ/CPP/boj7511.cpp
+++ b/aeongseo/BOJ/CPP/boj7511.cpp
@@ -1,0 +1,67 @@
+/*** 7511. 소셜 네트워킹 어플리케이션 */
+
+#include<iostream>
+#include<vector>
+#include<algorithm>
+using namespace std;
+
+int find_set(int x);
+void merge(int x, int y);
+
+vector<int> parent;	// 부모노드
+vector<int> ran;	// rank
+
+int main() {
+	int T;
+	cin >> T;
+	for (int tc = 1; tc < T + 1; tc++) {
+		vector<int> ans;
+		int n, k, m;
+		cin >> n >> k;
+		parent.assign(n, 0);
+		ran.assign(n, 0);
+
+		// make set
+		for (int i = 0; i < n; i++) {
+			parent[i] = i;
+			ran[i] = 1;
+		}
+		
+		for (int j = 0; j < k; j++) {
+			int a, b;
+			cin >> a >> b;
+			merge(a, b);	// 두 노드 연결하기
+		}
+
+		cin >> m;
+		for (int k = 0; k < m; k++) {
+			int c, d;
+			cin >> c >> d;
+			if (find_set(c) == find_set(d)) ans.push_back(1); // 두 노드의 부모 노드가 같으면 1 저장
+			else ans.push_back(0);	// 부모 노드가 다르면 0 저장
+		}
+
+		cout << "Scenario " << tc << ":" << '\n';
+		for (int l = 0; l < ans.size(); l++) {
+			cout << ans[l] << '\n';
+		}
+		cout << '\n';
+	}
+
+	return 0;
+}
+
+int find_set(int x) {
+	if (x == parent[x]) return x;	// x의 부모 노드가 자기자신이라면 x 반환
+	return parent[x] = find_set(parent[x]);
+}
+
+void merge(int x, int y) {
+	x = find_set(x);	// x의 부모 노드 찾기
+	y = find_set(y);	// y의 부모 노드 찾기
+
+	if (x == y) return;	// x와 y의 부모 노드가 같다면 병합 성공
+	if (ran[x] > ran[y]) swap(x, y);	// x의 깊이가 y의 깊이보다 높으면 swap
+	parent[x] = y;	// x의 부모노드를 y로 저장
+	if (ran[x] == ran[y]) ran[y]++;	// x와 y의 깊이가 같으면 y의 깊이 1 증가
+}


### PR DESCRIPTION
---
## 🎈boj 1759 암호 만들기
<br>
바로 어제 최백준 조교가 방 열쇠를 주머니에 넣은 채 깜빡하고 서울로 가 버리는 황당한 상황에 직면한 조교들은, 702호에 새로운 보안 시스템을 설치하기로 하였다. 이 보안 시스템은 열쇠가 아닌 암호로 동작하게 되어 있는 시스템이다.

암호는 서로 다른 L개의 알파벳 소문자들로 구성되며 최소 한 개의 모음(a, e, i, o, u)과 최소 두 개의 자음으로 구성되어 있다고 알려져 있다. 또한 정렬된 문자열을 선호하는 조교들의 성향으로 미루어 보아 암호를 이루는 알파벳이 암호에서 증가하는 순서로 배열되었을 것이라고 추측된다. 즉, abc는 가능성이 있는 암호이지만 bac는 그렇지 않다.

새 보안 시스템에서 조교들이 암호로 사용했을 법한 문자의 종류는 C가지가 있다고 한다. 이 알파벳을 입수한 민식, 영식 형제는 조교들의 방에 침투하기 위해 암호를 추측해 보려고 한다. C개의 문자들이 모두 주어졌을 때, 가능성 있는 암호들을 모두 구하는 프로그램을 작성하시오.

[입력]

첫째 줄에 두 정수 L, C가 주어진다. (3 ≤ L ≤ C ≤ 15) 다음 줄에는 C개의 문자들이 공백으로 구분되어 주어진다. 주어지는 문자들은 알파벳 소문자이며, 중복되는 것은 없다.

[출력]

각 줄에 하나씩, 사전식으로 가능성 있는 암호를 모두 출력한다.

#### 🗨 해결방법 :
<br>

- 조합과 백트래킹 알고리즘을 사용하였다.
    - 문자를 입력받고 오름차순으로 정렬한다.
    - 문자열을 순회하며 조합을 생성한다.
    - 생성된 조합이 최소한의 자모음 개수를 충족한다면 출력한다.

#### 📝메모 : 
<br>

- 문제를 또!! 제대로 안읽어서 모음과 자음의 최소한의 개수 조건을 걸지 않아 틀렸다. 줄글이 읽기 싫은가 보다.
- 모음, 자음 개수를 전역변수로 선언하여 자모음 체크하는 함수와 자모음 개수를 하나 빼는 함수를 만들었는데, 개수가 제대로 카운트되지 않는 문제가 발생했다.
    - 자모음 개수를 하나 빼는 위치가 정말 애매했다.
    - 백트래킹 함수의 매개변수로 자모음 개수를 받아 개수 빼는 코드가 필요없도록 하였다.

---
## 🎈boj 1707 이분 그래프
<br>

그래프의 정점의 집합을 둘로 분할하여, 각 집합에 속한 정점끼리는 서로 인접하지 않도록 분할할 수 있을 때, 그러한 그래프를 특별히 이분 그래프 (Bipartite Graph) 라 부른다.

그래프가 입력으로 주어졌을 때, 이 그래프가 이분 그래프인지 아닌지 판별하는 프로그램을 작성하시오.

[입력]

입력은 여러 개의 테스트 케이스로 구성되어 있는데, 첫째 줄에 테스트 케이스의 개수 K가 주어진다. 각 테스트 케이스의 첫째 줄에는 그래프의 정점의 개수 V와 간선의 개수 E가 빈 칸을 사이에 두고 순서대로 주어진다. 각 정점에는 1부터 V까지 차례로 번호가 붙어 있다. 이어서 둘째 줄부터 E개의 줄에 걸쳐 간선에 대한 정보가 주어지는데, 각 줄에 인접한 두 정점의 번호 u, v (u ≠ v)가 빈 칸을 사이에 두고 주어진다.

[출력]

K개의 줄에 걸쳐 입력으로 주어진 그래프가 이분 그래프이면 YES, 아니면 NO를 순서대로 출력한다.

#### 🗨 해결방법 :
<br>

- dfs를 사용하여 해결하였다.
    - 인접 리스트를 양방향으로 생성하고, bfs를 통해 연결된 노드의 값과 반대되는 값을 다른 연결된 정점에 저장한다.
    - 만약 양쪽 노드 다 값이 저장되어 있는데, 값이 같을 경우 이분 그래프가 성립하지 않으므로 NO를 출력한다.

#### 📝메모 : 
<br>

- 이분 그래프는 같은 집합 안의 정점끼리 연결이 없다는 특징이라고 해서 처음에는 set을 만들어 했다. 그러다 아닌 것 같아서 백지로 돌아왔다.
- 두 번째에는 입력 받으면 바로 번호를 부여하는 방법이었다. 그러나 u를 1, v를 2로 설정하기에 u였던 값이 v로 입력되었을 때 값이 일치하지 않는 문제가 발생하였다.
- bfs를 한번만 사용하려고 하였더니 그래프가 모두 연결되지 않고 끊겨 있을 때 문제가 발생했다. visited를 순회하며 방문하지 않은 정점에 대해 bfs를 수행하도록 하였다.

---
## 🎈boj 7511 소셜 네트워킹 어플리케이션
<br>

어렸을때부터 컴퓨터 프로그래밍에 엄청난 소질을 보인 상근이는 항상 소셜 네트워킹 웹사이트를 만들고 싶어 했다. 상근이는 페이스북을 벤치마킹하기 위해 지난 3년간 열심히 사용을 했고, 이제 페이스북의 단점을 보완한 새 소셜 네트워킹 웹 2.0 어플리케이션을 만들려고 한다.

사람들은 소셜 네트워킹 어플리케이션에 가입을 한 다음, 현실에서 아는 사람을 친구로 추가하기 시작한다. 이러한 친구 관계 정보를 이용해 친구 관계 그래프를 그릴 수 있다.

소셜 네트워킹 어플리케이션에서 가장 중요한 기능은 한 사람이 다른 사람의 페이지를 방문했을 때, 친구 관계 그래프에서 두 사람 사이의 경로를 보여주는 기능이다. 경로가 없는 경우에는 보여주지 않는다.

상근이의 서비스는 매우 유명해졌고, 위의 기능은 사람들이 점점 많아질수록 경로를 구하는 시간이 매우 느려지게 되었다. 그 이유는 두 사람 사이의 경로가 없는 경우에 경로를 찾기 위해 너무 오랜시간 그래프를 탐색하기 때문이었다. 따라서, 상근이는 두 사람 사이의 경로가 존재하는지 안 하는지를 미리 구해보려고 한다.

유저의 수와 각 유저의 친구 관계가 입력으로 주어진다. 이때, 주어지는 두 사람이 친구 관계 그래프상에서 경로가 존재하는지 안 하는지를 구하는 프로그램을 작성하시오.

[입력]

입력은 여러 개의 테스트 케이스로 이루어져 있다.

각 테스트 케이스의 첫째 줄에는 유저의 수 1 ≤ n ≤ 106이 주어진다. 둘째 줄에는 친구 관계의 수 1 ≤ k ≤ 105가 주어진다. 다음 k개 줄에는 두 정수 0 ≤ a, b < n이 주어진다. 두 수는 친구 관계를 나타내며, 유저 a와 b가 친구라는 소리이다. 다음 줄에는 미리 구할 쌍의 수 1 ≤ m ≤ 105가 주어진다. 다음 m개 줄에는 구해야하는 쌍을 나타내는 u, v가 주어진다.

[출력]

각 테스트 케이스마다 "Scenario i:"를 출력한다. i는 테스트 케이스 번호이며, 1부터 시작한다. 그 다음, 각각의 쌍마다 두 사람을 연결하는 경로가 있으면 1, 없으면 0을 출력한다.

각 테스트 케이스 사이에는 빈 줄을 하나 출력한다.

#### 🗨 해결방법 :
<br>

- 유니온 파인드를 사용하였다.
    - 모든 노드에 대해서 부모 노드를 자기 자신으로 저장한다.
    - ran은 트리의 깊이를 의미한다. 트리가 모두 자기자신 노드밖에 없으므로 모두 1로 저장한다.
    - 연결해야 하는 두 노드를 합친다.
        - 두 노드의 루트 노드를 찾는다.
        - 루트 노드가 같다면 병합을 종료한다.
        - x의 깊이가 y의 깊이보다 깊으면 둘의 값을 바꾸고 x의 부모 노드에 y를 저장한다.
        - 만약 둘의 깊이가 같다면 합쳤을 때 실제 깊이는 1 증가하므로 y의 깊이를 1 증가시킨다.
    - 비교하고자 하는 두 노드의 루트 노드가 같다면 1을 출력하고, 다르다면 0을 출력한다.

#### 📝메모 : 
<br>

- 분리집합이 뭔가 했더니 유니온 파인드였다…
- 처음에 유니온 파인드인 줄 모르고 그냥 간선 그려져 있으면 이어져 있고, 없으면 떨어져 있다고 생각했는데, 여러 간선으로 이어진 것도 이어졌다고 봐야 하므로 그 코드는 틀렸었다.
