### PR TITLE
miayujeong / 9월 4주차 / 목

### DIFF
--- a/yujeong/BOJ/boj1926.py
+++ b/yujeong/BOJ/boj1926.py
@@ -1,0 +1,38 @@
+# 1926. 그림
+import sys
+input = sys.stdin.readline
+from collections import deque
+
+# BFS로 연결된 영역을 탐색하며 가장 넓은 그림 크기를 갱신하는 함수 bfs()
+def bfs(x, y):
+    global cnt, max_area
+    q = deque()
+    q.append((x, y))
+    visited[x][y] = True
+    temp = 0    # 이번 그림의 크기
+    while q:
+        px, py = q.pop()
+        temp += 1   
+        for dx, dy in [(0, 1), (1, 0), (0, -1), (-1, 0)]:
+            nx, ny = px + dx, py + dy
+            if 0 <= nx < n and 0 <= ny < m and not visited[nx][ny] and board[nx][ny]:
+                q.append((nx, ny))
+                visited[nx][ny] = True
+    max_area = max(temp, max_area)
+
+
+n, m = map(int, input().split())
+board = [list(map(int, input().split())) for _ in range(n)]
+cnt = 0         # 그림 개수
+max_area = 0    # 가장 넓은 그림 크기 
+visited = [[False] * m for _ in range(n)]
+
+for i in range(n):
+    for j in range(m):
+        # 그림이 있는 영역이고 아직 탐색하지 않았으면 bfs()
+        if board[i][j] == 1 and not visited[i][j]:  
+            bfs(i, j)
+            cnt += 1  
+
+print(cnt)
+print(max_area)

--- a/yujeong/BOJ/boj7662.py
+++ b/yujeong/BOJ/boj7662.py
@@ -1,0 +1,50 @@
+# 7662. 이중 우선순위 큐
+
+import sys
+input = sys.stdin.readline
+from heapq import heappush, heappop
+
+T = int(input())
+for _ in range(T):
+    k = int(input())    # 연산의 개수
+
+    maxheap, minheap = [], []   # 최대/최소값 관리
+    num_dict = dict()   # 큐에 갖고 있는 숫자별 개수 관리
+
+    for _ in range(k):
+        cmd, n = input().split()
+        n = int(n)
+
+        # 1. 삽입 연산 (I)
+        if cmd == 'I':
+            # if n in num_dict.keys():
+            #     num_dict[n] += 1
+            # else:
+            #     num_dict[n] = 1
+            num_dict[n] = num_dict.get(n, 0) + 1
+
+            heappush(minheap, n)
+            heappush(maxheap, -n)
+
+        # 2. 삭제 연산 (D)
+        else:
+            if n == 1:  # 최댓값 삭제
+                if maxheap:
+                    num_dict[-maxheap[0]] -= 1
+
+            else:       # 최솟값 삭제
+                if minheap:
+                    num_dict[minheap[0]] -= 1
+
+            # num_dict에서 최댓값/최솟값 개수를 일단 감소시켰고
+            # 그에 맞게 최대 힙, 최소 힙의 top 갱신 필요
+            # (num_dict[top]이 0이 된 경우 pop)
+            while maxheap and num_dict[-maxheap[0]] == 0:
+                heappop(maxheap)
+            while minheap and num_dict[minheap[0]] == 0:
+                heappop(minheap)
+
+    if minheap and maxheap:     # 큐가 비어있지 않으면 최댓값, 최솟값 출력
+        print(-maxheap[0], minheap[0])
+    else:                       # 아니면 'EMPTY' 출력
+        print('EMPTY')


### PR DESCRIPTION
---

## 🎈boj7662 - 이중 우선순위 큐

<br>

정수만 저장하는 이중 우선순위 큐 Q가 있다고 가정하자. Q에 저장된 각 정수의 값 자체를 우선순위라고 간주하자.

k 줄 각각엔 연산을 나타내는 문자(‘D’ 또는 ‘I’)와 정수 n이 주어진다. ‘I n’은 정수 n을 Q에 삽입하는 연산을 의미한다. ‘D 1’는 Q에서 최댓값을 삭제하는 연산을 의미하며, ‘D -1’는 Q 에서 최솟값을 삭제하는 연산을 의미한다. 최댓값(최솟값)을 삭제하는 연산에서 최댓값(최솟값)이 둘 이상인 경우, 하나만 삭제됨을 유념하기 바란다.

만약 Q가 비어있는데 적용할 연산이 ‘D’라면 이 연산은 무시해도 좋다. 

각 테스트 데이터에 대해, 모든 연산을 처리한 후 Q에 남아 있는 값 중 최댓값과 최솟값을 출력하라. 두 값은 한 줄에 출력하되 하나의 공백으로 구분하라. 만약 Q가 비어있다면 ‘EMPTY’를 출력하라.

<br>

#### 🗨 해결방법 :

연산의 개수가 아주 많을 수 있어 시간제한을 고려했을 때 `heapq`를 사용해 우선순위 큐의 삽입/삭제 연산을 구현해야 한다.

그런데 `heapq`로는 한 개의 큐로 이중 우선순위 (최솟값, 최댓값을 모두 찾기)를 구현할 수 없으므로, 최소 힙 `minheap`과 최대 힙 `maxheap`을 함께 사용한다. 최솟값을 삭제할 때는 `minheap`에서, 최댓값을 삭제할 때는 `maxheap`에서 `pop`연산으로 찾을 수 있다.

이때 파이썬 `heapq`는 최소 힙만 제공하기 때문에 최대 힙은 힙의 각 요소의 음수값으로 만들어 구현할 수 있다. 

이렇게 두 개의 힙 중 한쪽에서만 `pop`하다 보니 삭제 연산 후 두 힙의 `top`값이 실제 큐 상태와 다를 수 있다. 이를 관리하기 위해 실제 큐에 있는 각 숫자별 개수는 별개의 딕셔너리로 관리하고, 삭제 연산을 할 때마다 딕셔너리에 기록한 현재 큐의 상태와 일치하도록  `pop`연산으로 `top` 값을 맞춘다.

<br>

#### 📝메모 :

`heapq`로 최대 힙을 구현하려면 음수로 만들어 쓰면 된다는 아이디어를 알게되었다

<br>

---

## 🎈boj1926 - 그림

<br>

어떤 큰 도화지에 그림이 그려져 있을 때, 그 그림의 개수와, 그 그림 중 넓이가 가장 넓은 것의 넓이를 출력하여라. 단, 그림이라는 것은 1로 연결된 것을 한 그림이라고 정의하자. 가로나 세로로 연결된 것은 연결이 된 것이고 대각선으로 연결이 된 것은 떨어진 그림이다. 그림의 넓이란 그림에 포함된 1의 개수이다.

첫째 줄에는 그림의 개수, 둘째 줄에는 그 중 가장 넓은 그림의 넓이를 출력하라. 단, 그림이 하나도 없는 경우에는 가장 넓은 그림의 넓이는 0이다.

<br>

#### 🗨 해결방법 :

도화지의 각 영역(좌표) 중 그림(`1`)이고, 아직 탐색하지 않은 영역이면 그림 개수를 +1하고, 그 위치에서 BFS로 연결된 영역들을 탐색하며 그림의 넓이를 잰다. 

연결된 영역을 끝까지 탐색했을 때 이번 그림의 크기가 기존의 최대 그림 크기보다 크면 이번 그림의 크기로 업데이트한다.

<br>

#### 📝메모 :

<br>