### PR TITLE
ohjisu320 / 9월 4주차 / 목

### DIFF
--- a/ohjisu/BOJ/PYTHON/boj1926.py
+++ b/ohjisu/BOJ/PYTHON/boj1926.py
@@ -1,0 +1,70 @@
+'''
+# [Silver I] 그림 - 1926
+
+[문제 링크](https://www.acmicpc.net/problem/1926)
+
+### 성능 요약
+
+메모리: 120776 KB, 시간: 200 ms
+
+### 분류
+
+그래프 이론, 그래프 탐색, 너비 우선 탐색, 깊이 우선 탐색, 격자 그래프, 플러드 필
+
+### 제출 일자
+
+2025년 9월 26일 00:29:29
+
+### 문제 설명
+
+<p>어떤 큰 도화지에 그림이 그려져 있을 때, 그 그림의 개수와, 그 그림 중 넓이가 가장 넓은 것의 넓이를 출력하여라. 단, 그림이라는 것은 1로 연결된 것을 한 그림이라고 정의하자. 가로나 세로로 연결된 것은 연결이 된 것이고 대각선으로 연결이 된 것은 떨어진 그림이다. 그림의 넓이란 그림에 포함된 1의 개수이다.</p>
+
+### 입력
+
+ <p>첫째 줄에 도화지의 세로 크기 n(1 ≤ n ≤ 500)과 가로 크기 m(1 ≤ m ≤ 500)이 차례로 주어진다. 두 번째 줄부터 n+1 줄 까지 그림의 정보가 주어진다. (단 그림의 정보는 0과 1이 공백을 두고 주어지며, 0은 색칠이 안된 부분, 1은 색칠이 된 부분을 의미한다)</p>
+
+### 출력
+
+ <p>첫째 줄에는 그림의 개수, 둘째 줄에는 그 중 가장 넓은 그림의 넓이를 출력하여라. 단, 그림이 하나도 없는 경우에는 가장 넓은 그림의 넓이는 0이다.</p>
+
+'''
+from collections import deque
+import sys
+input = lambda : sys.stdin.readline().rstrip()
+
+DIRS = [[0, 1], [1, 0], [0, -1], [-1, 0]]
+def bfs(start_i, start_j) :
+    q = deque([(start_i, start_j)])
+    visited[start_i][start_j] = 1
+    dist = 1
+
+    while q :
+        i, j = q.popleft()
+
+        for di, dj in DIRS :
+            ni, nj = i + di, j + dj
+            if not (0 <= ni < n and 0 <= nj < m) : # 범위 체크
+                continue
+            if visited[ni][nj]: # 방문 체크
+                continue
+            if not graph[ni][nj] : # 연결되는 지 체크
+                continue
+            visited[ni][nj] = 1 # 표시
+            dist += 1 # 거리 업데이트
+            q.append((ni, nj)) # 다음 탐색 자리 추가
+    return dist
+
+n, m = map(int, input().split())
+graph = [list(map(int, input().split())) for _ in range(n)]
+visited = [[0]*m for _ in range(n)]
+
+max_dist = 0
+cnt = 0
+for i in range(n) :
+    for j in range(m):
+        if graph[i][j] and not visited[i][j] :
+            cnt += 1
+            max_dist = max(max_dist, bfs(i, j))
+
+print(cnt)
+print(max_dist)

--- a/ohjisu/BOJ/PYTHON/boj7662.py
+++ b/ohjisu/BOJ/PYTHON/boj7662.py
@@ -1,0 +1,78 @@
+'''
+# [Gold IV] 이중 우선순위 큐 - 7662
+
+[문제 링크](https://www.acmicpc.net/problem/7662)
+
+### 성능 요약
+
+메모리: 355068 KB, 시간: 3480 ms
+
+### 분류
+
+자료 구조, 집합과 맵, 트리를 사용한 집합과 맵, 우선순위 큐
+
+### 제출 일자
+
+2025년 9월 24일 17:27:50
+
+### 문제 설명
+
+<p>이중 우선순위 큐(dual priority queue)는 전형적인 우선순위 큐처럼 데이터를 삽입, 삭제할 수 있는 자료 구조이다. 전형적인 큐와의 차이점은 데이터를 삭제할 때 연산(operation) 명령에 따라 우선순위가 가장 높은 데이터 또는 가장 낮은 데이터 중 하나를 삭제하는 점이다. 이중 우선순위 큐를 위해선 두 가지 연산이 사용되는데, 하나는 데이터를 삽입하는 연산이고 다른 하나는 데이터를 삭제하는 연산이다. 데이터를 삭제하는 연산은 또 두 가지로 구분되는데 하나는 우선순위가 가장 높은 것을 삭제하기 위한 것이고 다른 하나는 우선순위가 가장 낮은 것을 삭제하기 위한 것이다. </p>
+
+<p>정수만 저장하는 이중 우선순위 큐 Q가 있다고 가정하자. Q에 저장된 각 정수의 값 자체를 우선순위라고 간주하자. </p>
+
+<p>Q에 적용될 일련의 연산이 주어질 때 이를 처리한 후 최종적으로 Q에 저장된 데이터 중 최댓값과 최솟값을 출력하는 프로그램을 작성하라.</p>
+
+### 입력
+
+ <p>입력 데이터는 표준입력을 사용한다. 입력은 T개의 테스트 데이터로 구성된다. 입력의 첫 번째 줄에는 입력 데이터의 수를 나타내는 정수 T가 주어진다. 각 테스트 데이터의 첫째 줄에는 Q에 적용할 연산의 개수를 나타내는 정수 k (k ≤ 1,000,000)가 주어진다. 이어지는 k 줄 각각엔 연산을 나타내는 문자(‘D’ 또는 ‘I’)와 정수 n이 주어진다. ‘I n’은 정수 n을 Q에 삽입하는 연산을 의미한다. 동일한 정수가 삽입될 수 있음을 참고하기 바란다. ‘D 1’는 Q에서 최댓값을 삭제하는 연산을 의미하며, ‘D -1’는 Q 에서 최솟값을 삭제하는 연산을 의미한다. 최댓값(최솟값)을 삭제하는 연산에서 최댓값(최솟값)이 둘 이상인 경우, 하나만 삭제됨을 유념하기 바란다.</p>
+
+<p>만약 Q가 비어있는데 적용할 연산이 ‘D’라면 이 연산은 무시해도 좋다. Q에 저장될 모든 정수는 -2<sup>31</sup> 이상 2<sup>31</sup> 미만인 정수이다. </p>
+
+### 출력
+
+ <p>출력은 표준출력을 사용한다. 각 테스트 데이터에 대해, 모든 연산을 처리한 후 Q에 남아 있는 값 중 최댓값과 최솟값을 출력하라. 두 값은 한 줄에 출력하되 하나의 공백으로 구분하라. 만약 Q가 비어있다면 ‘EMPTY’를 출력하라.</p>
+
+'''
+from heapq import heappush, heappop
+
+T = int(input()) # 테스트케이스
+for _ in range(T) :
+    k = int(input()) # 연산 수행하는 횟수
+    min_hq = []
+    max_hq = []
+    visited = [0] * k # 힙에 들어간 숫자 체크용
+
+    for i in range(k) :
+        command, n = input().split()
+        n = int(n)
+
+        if command == 'I' :
+            heappush(min_hq, (n, i))
+            heappush(max_hq, (-n, i))
+            visited[i] = 1
+
+        else :
+            if n == 1 :
+                while max_hq and not visited[max_hq[0][1]]:
+                    heappop(max_hq)
+                if max_hq :
+                    visited[max_hq[0][1]] = 0
+                    heappop(max_hq)
+            elif n == -1:
+                while min_hq and not visited[min_hq[0][1]] :
+                    heappop(min_hq)
+                if min_hq :
+                    visited[min_hq[0][1]] = 0
+                    heappop(min_hq)
+
+
+    while max_hq and not visited[max_hq[0][1]]:
+        heappop(max_hq)
+    while min_hq and not visited[min_hq[0][1]]:
+        heappop(min_hq)
+
+    if min_hq and max_hq :
+        print(-heappop(max_hq)[0], heappop(min_hq)[0])
+    else :
+        print('EMPTY')


### PR DESCRIPTION
<!-- ----- 여기부터 복사 ----- -->
---
## 🎈BOJ7662 / D3 - 이중 우선순위 큐
<p>
최댓값/최솟값을 동시에 삭제할 수 있는 우선순위 큐를 구현하는 문제.  
Python의 heapq는 최소힙만 지원하므로, <strong>최대힙을 위해 음수 변환</strong>과  
<strong>visited 배열을 통한 유효성 체크</strong>를 병행해야 함.
</p>

<br>

#### 🗨 해결방법 :
- 연산마다 인덱스를 부여하고, 삽입 시 `(값, 인덱스)` 형태로 각각 `min_hq`, `max_hq`에 push  
- visited 배열을 사용하는게 포인트
  - 삽입 시 `visited[i] = 1` 로 표시  
  - 삭제 시 `visited[i] = 0` 으로 무효화  
  - 힙에서 pop할 때, `visited`가 0이면 이미 삭제된 값이므로 무시  

<br>

#### 📝메모 :
- 힙을 이중으로 돌리는 게 어려워서 제미나이의 힘을 빌릴 수 밖에 없었다.
- `heapq`는 최소힙만 지원하므로 최대힙은 `( -값, 인덱스 )` 형태로 저장  
- 삽입/삭제 모두 `O(log N)` → 총 `O(k log k)`로 충분히 처리 가능  
- k가 최대 1,000,000이므로 sys.stdin.readline 필수  

<br>


<!-- ----- 여기까지 복사 ----- -->
<!-- ----- 여기부터 복사 ----- -->
---
## 🎨 BOJ1926 / D2 - 그림
<p>
도화지에서 <strong>1로 연결된 영역(그림)</strong>의 개수와, 그 중 가장 넓은 그림의 넓이를 구하는 문제.  
연결은 <strong>상하좌우</strong>만 인정되며, 대각선은 연결되지 않은 것으로 본다.
</p>

<br>

#### 🗨 해결방법 :
- BFS 탐색으로 그림 영역(1로 연결된 부분)을 확장하면서 넓이를 구함  
- 방문 처리를 위한 `visited` 배열 사용  
- 각 시작점에서 BFS를 실행 → 그림 하나 완성 시 `cnt += 1`  
- BFS 과정에서 영역의 넓이를 계산 → `max_dist` 갱신  

<br>

#### 📝메모 :
- 방향벡터 `DIRS = [[0,1],[1,0],[0,-1],[-1,0]]` 로 상하좌우 탐색  
- 범위/방문/값(0인지 1인지) 체크 후 큐에 삽입  
- 그림이 없을 경우 넓이는 0으로 출력  

<br>


<!-- ----- 여기까지 복사 ----- -->
