### PR TITLE
miayujeong / 10월 1주차 / 목

### DIFF
--- a/yujeong/BOJ/boj11559.py
+++ b/yujeong/BOJ/boj11559.py
@@ -1,0 +1,61 @@
+# 11559. Puyo Puyo
+from collections import deque
+
+# 상하좌우로 같은 색 뿌요 4개가 연결되었는지 찾아 좌표들을 반환하는 함수 bfs()
+def bfs(pos):
+    q = deque([pos])
+    cnt = 0
+    color = field[pos[0]][pos[1]]
+    pop_pos = []
+    while q:
+        px, py = q.popleft()
+        for dx, dy in [(0, 1), (1, 0), (0, -1), (-1, 0)]:
+            nx, ny = px+dx, py+dy
+            if 0<=nx<12 and 0<=ny<6 and field[nx][ny] == color and not visited[nx][ny]:
+                cnt += 1
+                q.append((nx, ny))
+                visited[nx][ny] = True
+                pop_pos.append((nx, ny))
+    if cnt >= 4:    # 4개 이상 모여 있음
+        return pop_pos
+    return False    # 터뜨릴 뿌요 없음 
+
+# 뿌요들이 터진 후 아래로 떨어지게 하는 함수 clean()
+def clean():
+    for w in range(6):
+        puyo = deque()  # 빈칸이 아닌 (아래로 떨어져야 하는) 뿌요들 차례로 담기
+        for h in range(11, -1, -1): # 아래에서부터 위로 
+            if field[h][w] != '.':
+                puyo.append(field[h][w])
+        for h in range(11, -1, -1):
+            if puyo:    # 다시 맨 아래에서부터 뿌요 차례로 넣기
+                field[h][w] = puyo.popleft()
+            else:       # 넣을 뿌요 없으면 빈칸
+                field[h][w] = '.'
+
+
+field = [list(input()) for _ in range(12)]      # 게임 필드
+ans = 0                                         # 뿌요들이 연쇄로 터진 횟수 저장
+
+# while문 1턴 = 1연쇄
+while True:
+    visited = [[False] * 6 for _ in range(12)]      # 한 턴에 같은 좌표는 한 번만 방문
+    clear_lst = deque()                             # 이번 턴에 연쇄로 터뜨릴 뿌요들 좌표
+    # 게임 맵 순회하며 같은 색 뿌요 4개 모인 곳 찾기
+    for i in range(12):
+        for j in range(6):
+            if field[i][j] != '.' and not visited[i][j]:
+                pop_lst = bfs((i, j))
+                if pop_lst:     # 모인 뿌요들 있으면 터뜨릴 좌표 리스트에 추가 
+                    clear_lst += pop_lst
+
+    if not clear_lst:   # 터질 뿌요가 없는 경우; 
+        break
+
+    for x, y in clear_lst:  # 터질 뿌요가 있는 경우;
+        field[x][y] = '.'   # 터뜨리고 빈칸으로 만들기 
+
+    clean()     # 뿌요들 아래에 빈칸이 있으면 아래로 떨어지게
+    ans += 1    # 연쇄 횟수 +1
+
+print(ans)

--- a/yujeong/BOJ/boj2211.py
+++ b/yujeong/BOJ/boj2211.py
@@ -1,0 +1,40 @@
+# 2211. 네트워크 복구
+import sys
+input = sys.stdin.readline
+from heapq import heappop, heappush
+INF = float('inf')  # 다익스트라로 최소비용 구할 때 초깃값으로 담을 임의의 큰 값 
+
+# 다익스트라 알고리즘으로 각 컴퓨터까지 최소비용 거리 계산해 반환할 함수 dijkstra()
+def dijkstra(pos):
+    pq = [(0, pos)]     # (걸리는 시간, 컴퓨터 번호)
+    node_info = [[INF, 0] for _ in range(N+1)]  # 각 노드별로 (걸리는 시간, 이어지는 노드) 정보 저장
+    node_info[1][0] = 0
+
+    while pq:
+        cost, curr = heappop(pq)
+        if cost > node_info[curr][0]:
+            continue
+        for nxt, w in network[curr]:
+            new_cost = w + cost
+            if new_cost < node_info[nxt][0]:    # 새 비용이 더 작은 경우
+                node_info[nxt][0] = new_cost    # 비용 갱신
+                node_info[nxt][1] = curr        # 연결된 노드 갱신
+                heappush(pq, (new_cost, nxt))
+    return node_info
+
+
+N, M = map(int, input().split())    # N개의 컴퓨터, M개 회선
+
+network = [[] for _ in range(N+1)]      # 양방향 그래프로 간선과 가중치(통신에 걸리는 시간) 정보 담기
+for _ in range(M):
+    a, b, c = map(int, input().split())
+    network[a].append((b, c))
+    network[b].append((a, c))
+
+# 1번 컴퓨터가 보안 시스템이 설치된 슈퍼컴퓨터이므로, 
+# 1번에서부터 각 컴퓨터들에 연결되기 위해 필요한 최소 시간과 이어져야 할 노드를 찾기
+ans = dijkstra(1)
+
+print(N-1)      # 최소 개수 간선으로 모든 노드에 연결할 때 간선 횟수는 N-1
+for x in range(2, N+1): 
+    print(x, ans[x][1])     # 최소 비용으로 각 노드에 연결된 노드 정보 출력


### PR DESCRIPTION
---

## 🎈boj11559 - Puyo Puyo

<br>

뿌요뿌요의 룰은 다음과 같다.

> 필드에 여러 가지 색깔의 뿌요를 놓는다. 뿌요는 중력의 영향을 받아 아래에 바닥이나 다른 뿌요가 나올 때까지 아래로 떨어진다.
> 
> 
> 뿌요를 놓고 난 후, 같은 색 뿌요가 4개 이상 상하좌우로 연결되어 있으면 연결된 같은 색 뿌요들이 한꺼번에 없어진다. 이때 1연쇄가 시작된다.
> 
> 뿌요들이 없어지고 나서 위에 다른 뿌요들이 있다면, 역시 중력의 영향을 받아 차례대로 아래로 떨어지게 된다.
> 
> 아래로 떨어지고 나서 다시 같은 색의 뿌요들이 4개 이상 모이게 되면 또 터지게 되는데, 터진 후 뿌요들이 내려오고 다시 터짐을 반복할 때마다 1연쇄씩 늘어난다.
> 
> 터질 수 있는 뿌요가 여러 그룹이 있다면 동시에 터져야 하고 여러 그룹이 터지더라도 한번의 연쇄가 추가된다.
> 

필드가 주어졌을 때, 연쇄가 몇 번 연속으로 일어날지 출력한다.

입력으로 주어지는 필드는 뿌요들이 전부 아래로 떨어진 뒤의 상태이다. 즉, 뿌요 아래에 빈 칸이 있는 경우는 없다.

<br>

#### 🗨 해결방법 :

BFS로 필드를 탐색하며 터뜨릴 뿌요가 있는지 찾고, (연속으로)터뜨린 경우 중력에 따라 아래로 떨어뜨리기

이번 턴에 터질 수 있는 뿌요가 여러 그룹이 있으면 동시에 터뜨려야 하므로, `while`문 안에서 필드 탐색을 진행한다. 이번 `while` 문 내에서 한 좌표는 한 번만 방문하며, 각 좌표에서 BFS로 탐색해 상하좌우로 같은 색의 뿌요가 4개 이상 모인 경우가 있는지 찾는다. 이 조건을 만족한다면 이번 턴에 터뜨릴 뿌요들의 좌표 `clear_lst`에 추가한다.

이번 턴에서 터뜨릴 뿌요들을 모두 찾고 나면 터뜨려 빈칸(`.`)으로 만든다. 그리고 중력에 따라 뿌요 아래에 빈칸이 있으면 아래로 떨어뜨리기 위해 `clean()`을 실행해 뿌요들이 가장 아래로 모이게 한다.

연쇄가 끊기면 그때까지 뿌요를 연속으로 터뜨린 (연쇄) 횟수를 출력한다.

<br>

#### 📝메모 :

터뜨릴 뿌요를 찾아 터뜨리는 것까지는 쉽게 해결할 수 있었지만 어떻게 뿌요들을 아래로 떨어뜨릴지 많이 고민했다. 

필드가 작아서 루프를 두 번 돌며 빈칸이 아닌 값들(=뿌요)을 모아서 다시 아래에서부터 쌓는 방식으로 구현했다.

<br>

---

## 🎈boj2211 - 네트워크 복구

<br>

N개의 컴퓨터로 구성된 네트워크가 있다. 컴퓨터 간 통신을 할 때에는 서로 직접 연결되어 있는 회선을 이용할 수도 있으며, 회선과 다른 컴퓨터를 거쳐서 통신을 할 수도 있다.

어느 날, 해커가 네트워크에 침입하였다. 네트워크의 관리자는 우선 모든 회선과 컴퓨터를 차단한 후, 해커의 공격을 막을 수 있었다. 

관리자는 다시 네트워크를 복구하기로 하였다. 이때, 다음의 조건들이 만족되어야 한다.

1. 해커가 다시 공격을 할 우려가 있기 때문에, 최소 개수의 회선만을 복구해야 한다. 
2. 슈퍼컴퓨터가 다른 컴퓨터들과 통신하는데 걸리는 최소 시간이 원래의 네트워크에서 통신하는데 걸리는 최소 시간보다 커져서는 안 된다.

원래의 네트워크에 대한 정보가 주어졌을 때, 위의 조건을 만족하면서 네트워크를 복구하는 방법을 알아내는 프로그램을 작성하시오.

컴퓨터들의 번호는 1부터 N까지의 정수이며, 1번 컴퓨터는 보안 시스템을 설치할 슈퍼컴퓨터이다. 한 회선으로 연결된 두 컴퓨터는 어느 방향으로도 통신할 수 있다.

첫째 줄에 복구할 회선의 개수 K를 출력한다. 다음 K개의 줄에는 복구한 회선을 나타내는 두 정수 A, B를 출력한다. 이는 A번 컴퓨터와 B번 컴퓨터를 연결하던 회선을 복구한다는 의미이다. 출력은 임의의 순서대로 하며, 답이 여러 개 존재하는 경우에는 아무 것이나 하나만 출력하면 된다.

<br>

#### 🗨 해결방법 :

다익스트라 알고리즘으로 슈퍼컴퓨터에서 각 컴퓨터에 최소 비용으로 연결되기 위한 연결 노드 찾기

일단 조건이 복잡하지만 생각해보면 다익스트라 알고리즘으로 슈퍼컴퓨터(1번 컴퓨터)에서부터 탐색하면 이 알고리즘의 성격상 1, 2번 조건 모두 이미 만족된 상태가 된다.

1번 컴퓨터(슈퍼컴퓨터)에서 각 컴퓨터들에 최소 비용으로 연결될 때 각 컴퓨터의 정보를 `node_info` 배열에 `(비용, 연결된 이전 노드)` 로 기록한다. 

다익스트라 탐색을 마친 후 이 배열에 기록되어 있는 `연결된 노드` 정보가 최소 개수/비용 회선으로 연결을 복구했을 때 회선 정보이다.

<br>

#### 📝메모 :

다익스트라로 1번 노드를 루트로 하는 (다른 모든 노드들에 연결되는) 트리를 만든다고 생각

<br>