### PR TITLE
nancykim99 / 4월 2주차

### DIFF
--- a/nancykim99/boj/python/boj1167.py
+++ b/nancykim99/boj/python/boj1167.py
@@ -1,0 +1,69 @@
+'''
+BOJ1167 : 트리의 지름 (G2)
+
+해결 방법 : 
+트리를 전체로 입력 받아서 e, w로 각 시작 노드에 맞게 넣고, -1은 제거하기
+dfs로 가중치를 추가하면서 한 번 돌리고, 더 먼 노드를 찾기 위해 dfs를 한 번 더 돌리기
+트리의 각 끝 점이 첫 dfs를 돌렸을 때 안 나올 수 있기 때문
+
+메모 : 
+현재 시간복잡도 : O(V) / 공간복잡도 : O(V)
+    노드 수 V = 최대 100,000
+    간선 수 E = V - 1 (트리 성질)
+    DFS 2회 수행 = O(V + E) * 2 = O(V)
+    각 노드 정확히 1번만 방문 (visited == -1 체크)
+    스택 최대 깊이 = O(V) (일자 트리 최악의 경우)
+    defaultdict 탐색 = 매 루프마다 hash 탐색 발생
+    visited = [-1] * (v+1) = DFS마다 O(V) 초기화 * 2회
+    tree = defaultdict(list) = 간선 입력마다 동적 리스트 생성
+
+최적화 방법 :
+    1. defaultdict(list) → [[] for _ in range(v+1)] 로 변경
+       → hash 탐색 제거, 인덱스 직접 접근으로 단축
+       → 메모리 한 번에 할당, 동적 리스트 생성 제거
+    2. visited = [-1] * (v+1) → 재사용 가능하도록 함수 밖 선언 후 memset 방식으로 초기화
+       → DFS 2회마다 새 리스트 생성 제거
+    3. stack = [(start, 0)] 선언과 동시에 초기화
+       → list() + append() 2번 호출 → 1번으로 단축
+    4. max(visited), visited.index(max_dist) 2번 순회
+       → enumerate로 1번 순회로 단축
+       → O(2V) → O(V)
+'''
+import sys
+input = sys.stdin.readline
+
+from collections import defaultdict
+
+# 트리의 정점의 개수
+v = int(input())
+tree = defaultdict(list)
+
+for _ in range(v):
+    # 정점 번호 및 거리 입력받기
+    line = list(map(int, input().split()))
+    s = line[0]
+    i = 1
+    while line[i] != -1:
+        e, w = line[i], line[i + 1]
+        tree[s].append((e, w))
+        i += 2
+
+# dfs로 가장 거리 찾기
+def find_longest(start):
+    visited = [-1] * (v + 1)
+    stack = [(start, 0)]
+    while stack:
+        node, dist = stack.pop()
+        if visited[node] == -1:
+            visited[node] = dist
+            for e, w in tree[node]:
+                if visited[e] == -1:
+                    stack.append((e, dist + w))
+    
+    max_dist = max(visited)
+    max_node = visited.index(max_dist)
+    return max_node, max_dist
+
+first_node, first_ans = find_longest(1)
+ans_node, ans = find_longest(first_node)
+print(ans)

--- a/nancykim99/boj/python/boj1261.py
+++ b/nancykim99/boj/python/boj1261.py
@@ -1,0 +1,68 @@
+'''
+BOJ1261 : 알고스팟 (G4)
+
+해결 방법 : 
+bfs에서 0이면 appendleft, 1이면 append하는 방식으로 0인 길을 먼저 가보기
+1로 가는 경우, 거리를 갱신하고, 거리가 더 짧은 경우 갱신하기
+
+메모 : 
+현재 시간복잡도 : O(N × M) / 공간복잡도 : O(N × M)
+    노드 수 V = N × M = 최대 100 × 100 = 10,000
+    간선 수 E = 4 × N × M (상하좌우 4방향)
+    0-1 BFS 1회 수행 = O(V + E) = O(5 × N × M) = O(N × M)
+    각 칸은 new_cost < dist 조건일 때만 큐에 재추가
+    deque 최대 크기 = O(N × M)
+    방향벡터 [(0,1),(1,0),(0,-1),(-1,0)] = 루프마다 리스트 생성 발생
+    float('inf') = 정수보다 느린 float 비교 연산
+    board[ni][nj] = 2D 인덱싱 2번 접근
+    dist[ti][tj] = 2D 인덱싱 2번 접근
+    전역 dist, board = bfs() 내부에서 매번 LEGB 룰 탐색 발생
+
+최적화 방법 :
+    1. float('inf') → n * m + 1 정수로 변경
+       → 벽 최대 개수 = 10,000 이므로 10,001이면 INF로 충분
+       → 정수 비교가 float보다 빠름
+    2. board 2D → 1D 평탄화 board.extend()
+       → 2D 인덱싱 2번 → 1D 인덱싱 1번으로 단축
+       → 메모리 연속 할당으로 캐시 히트율 향상
+    3. dist 2D → 1D 평탄화
+       → 동일하게 인덱싱 2번 → 1번으로 단축
+    4. 방향벡터 DIRS = ((0,1),(1,0),(0,-1),(-1,0)) 전역 상수 선언
+       → 루프 40,000번 리스트 생성 → 전역 1번 tuple 생성으로 단축
+       → tuple이 list보다 메모리 적게 사용
+    5. _dist = dist / _board = board 지역 바인딩
+       → 전역 참조 LEGB 탐색 제거, 지역변수 접근이 더 빠름
+    6. cur = ti * m + tj 루프 밖에서 1번만 계산
+       → 매 방향 탐색마다 중복 계산 제거
+'''
+import sys
+input = sys.stdin.readline
+from collections import deque
+
+m, n = map(int, input().split())
+board = [list(map(int, input().strip())) for _ in range(n)]
+
+INF = float('inf')
+dist = [[INF] * m for _ in range(n)]
+dist[0][0] = 0
+
+def bfs():
+    q = deque()
+    q.append((0, 0))
+    while q:
+        ti, tj = q.popleft()
+        for si, sj in [(0, 1), (1, 0), (0, -1), (-1, 0)]:
+            ni, nj = ti + si, tj + sj
+            if 0 <= ni < n and 0 <= nj < m:
+                new_cost = dist[ti][tj] + board[ni][nj]
+                if new_cost < dist[ni][nj]:
+                    dist[ni][nj] = new_cost
+                    if board[ni][nj] == 0:
+                        q.appendleft((ni, nj))
+                    else:
+                        q.append((ni, nj))
+    return dist[n-1][m-1]
+
+ans = bfs()
+
+print(ans)

--- a/nancykim99/boj/python/boj5052.py
+++ b/nancykim99/boj/python/boj5052.py
@@ -1,0 +1,64 @@
+'''
+BOJ5052 : 전화번호 목록 (G4)
+
+해결 방법 : 
+트라이를 딕셔너리로 구현하여, 삽입 도중 _end를 만날 경우와, 이미 저장된 번호 이후로 저장해야 하는 상황을 예외로 잡음
+예외 상황이 발생할 경우, False로 인식하여 정상적이지 않은 전화번호 목록으로 판별
+
+메모 : 
+현재 시간복잡도 : O(T × N × L) / 공간복잡도 : O(N × L)
+    T = 테스트케이스 수
+    N = 테스트케이스당 전화번호 수 (최대 10,000)
+    L = 전화번호 길이 (최대 10)
+
+    테스트케이스 T번
+    └── N개 전화번호 삽입
+            └── 각 번호마다 L번 문자 순회
+                └── dict 접근 (setdefault, in 연산) : O(1) 해시
+
+    최악 노드 수 = N × L = 100,000개 (공유 prefix 없을 때)
+    테스트케이스마다 root = dict() 새로 생성 → GC 수거
+    동시에 존재하는 노드 = 한 테스트케이스분만
+최적화 방법 :
+    1. root = dict() → 전역 배열 [[-1] * 10 for _ in range(MAX_NODES)] 로 변경
+    → hash 탐색 제거, 인덱스 직접 접근으로 단축
+    → 메모리 한 번에 할당, 테스트케이스마다 동적 dict 생성/GC 제거
+
+    2. ord(ch) - ord('0') 로 문자 → 인덱스 직접 변환
+    → '0'→0, '1'→1, ..., '9'→9
+    → hash 계산 없이 배열 인덱스 직접 접근
+
+    3. '_end' in curr_dict → is_end[node] 배열로 관리
+    → dict 해시 탐색 → 배열 인덱스 직접 접근으로 단축
+
+    4. 테스트케이스마다 전체 배열 초기화 → 사용한 노드만 초기화
+    → O(MAX_NODES) → O(node_count) 로 단축
+'''
+import sys
+input = sys.stdin.readline
+
+def make_trie(*words):
+    root = dict()
+    for word in words:
+        curr_dict = root
+        for letter in word:
+            # 삽입 도중 _end를 만날 경우, 이미 저장된 번호가 삽입 번호의 prefix
+            if '_end' in curr_dict:
+                return False
+            curr_dict = curr_dict.setdefault(letter, {})
+        # 삽입을 완료한 후에도 남아 있을 경우, 삽입 완료한 번호가 이미 저장된 번호의 prefix
+        if len(curr_dict) > 0:
+            return False
+        curr_dict['_end'] = '_end'
+    return True
+
+test_case = int(input())
+for _ in range(test_case):
+    n = int(input()) # 전화번호의 수
+    phones = [input().strip() for _ in range(n)]
+    
+    ans = make_trie(*phones)
+    if ans == True:
+        print("YES")
+    else:
+        print("NO")


### PR DESCRIPTION
<!-- ----- 여기부터 복사 ----- -->
---
## 🎈BOJ1167 : 트리의 지름 (G2)
트리의 지름이란, 트리에서 임의의 두 점 사이의 거리 중 가장 긴 것을 말한다. 트리의 지름을 구하는 프로그램을 작성하시오.

입력
트리가 입력으로 주어진다. 먼저 첫 번째 줄에서는 트리의 정점의 개수 V가 주어지고 (2 ≤ V ≤ 100,000)둘째 줄부터 V개의 줄에 걸쳐 간선의 정보가 다음과 같이 주어진다. 정점 번호는 1부터 V까지 매겨져 있다.

먼저 정점 번호가 주어지고, 이어서 연결된 간선의 정보를 의미하는 정수가 두 개씩 주어지는데, 하나는 정점번호, 다른 하나는 그 정점까지의 거리이다. 예를 들어 네 번째 줄의 경우 정점 3은 정점 1과 거리가 2인 간선으로 연결되어 있고, 정점 4와는 거리가 3인 간선으로 연결되어 있는 것을 보여준다. 각 줄의 마지막에는 -1이 입력으로 주어진다. 주어지는 거리는 모두 10,000 이하의 자연수이다.

출력
첫째 줄에 트리의 지름을 출력한다.
<br>

#### 🗨 해결방법 :
트리를 전체로 입력 받아서 e, w로 각 시작 노드에 맞게 넣고, -1은 제거하기
dfs로 가중치를 추가하면서 한 번 돌리고, 더 먼 노드를 찾기 위해 dfs를 한 번 더 돌리기
트리의 각 끝 점이 첫 dfs를 돌렸을 때 안 나올 수 있기 때문
<br>


#### 📝메모 : 
현재 시간복잡도 : O(V) / 공간복잡도 : O(V)

    노드 수 V = 최대 100,000
    간선 수 E = V - 1 (트리 성질)
    DFS 2회 수행 = O(V + E) * 2 = O(V)
    각 노드 정확히 1번만 방문 (visited == -1 체크)
    스택 최대 깊이 = O(V) (일자 트리 최악의 경우)
    defaultdict 탐색 = 매 루프마다 hash 탐색 발생
    visited = [-1] * (v+1) = DFS마다 O(V) 초기화 * 2회
    tree = defaultdict(list) = 간선 입력마다 동적 리스트 생성

최적화 방법 :
1. defaultdict(list) → [[] for _ in range(v+1)] 로 변경
   → hash 탐색 제거, 인덱스 직접 접근으로 단축
   → 메모리 한 번에 할당, 동적 리스트 생성 제거

2. visited = [-1] * (v+1) → 재사용 가능하도록 함수 밖 선언 후 memset 방식으로 초기화
   → DFS 2회마다 새 리스트 생성 제거

3. stack = [(start, 0)] 선언과 동시에 초기화
   → list() + append() 2번 호출 → 1번으로 단축

4. max(visited), visited.index(max_dist) 2번 순회
   → enumerate로 1번 순회로 단축
   → O(2V) → O(V)
<br>

<!-- ----- 여기까지 복사 ----- -->
<!-- ----- 여기부터 복사 ----- -->
---
## 🎈BOJ5052 : 전화번호 목록 (G4)

전화번호 목록이 주어진다. 이때, 이 목록이 일관성이 있는지 없는지를 구하는 프로그램을 작성하시오.

전화번호 목록이 일관성을 유지하려면, 한 번호가 다른 번호의 접두어인 경우가 없어야 한다.

예를 들어, 전화번호 목록이 아래와 같은 경우를 생각해보자

긴급전화: 911
상근: 97 625 999
선영: 91 12 54 26
이 경우에 선영이에게 전화를 걸 수 있는 방법이 없다. 전화기를 들고 선영이 번호의 처음 세 자리를 누르는 순간 바로 긴급전화가 걸리기 때문이다. 따라서, 이 목록은 일관성이 없는 목록이다.

입력
첫째 줄에 테스트 케이스의 개수 t가 주어진다. (1 ≤ t ≤ 50) 각 테스트 케이스의 첫째 줄에는 전화번호의 수 n이 주어진다. (1 ≤ n ≤ 10000) 다음 n개의 줄에는 목록에 포함되어 있는 전화번호가 하나씩 주어진다. 전화번호의 길이는 길어야 10자리이며, 목록에 있는 두 전화번호가 같은 경우는 없다.

출력
각 테스트 케이스에 대해서, 일관성 있는 목록인 경우에는 YES, 아닌 경우에는 NO를 출력한다.
<br>

#### 🗨 해결방법 :
트라이를 딕셔너리로 구현하여, 삽입 도중 _end를 만날 경우와, 이미 저장된 번호 이후로 저장해야 하는 상황을 예외로 잡음
예외 상황이 발생할 경우, False로 인식하여 정상적이지 않은 전화번호 목록으로 판별
<br>


#### 📝메모 : 
현재 시간복잡도 : O(T × N × L) / 공간복잡도 : O(N × L)

    T = 테스트케이스 수
    N = 테스트케이스당 전화번호 수 (최대 10,000)
    L = 전화번호 길이 (최대 10)

    테스트케이스 T번
    └── N개 전화번호 삽입
            └── 각 번호마다 L번 문자 순회
                └── dict 접근 (setdefault, in 연산) : O(1) 해시

    최악 노드 수 = N × L = 100,000개 (공유 prefix 없을 때)
    테스트케이스마다 root = dict() 새로 생성 → GC 수거
    동시에 존재하는 노드 = 한 테스트케이스분만

최적화 방법 :
1. root = dict() → 전역 배열 [[-1] * 10 for _ in range(MAX_NODES)] 로 변경
    → hash 탐색 제거, 인덱스 직접 접근으로 단축
    → 메모리 한 번에 할당, 테스트케이스마다 동적 dict 생성/GC 제거

2. ord(ch) - ord('0') 로 문자 → 인덱스 직접 변환
    → '0'→0, '1'→1, ..., '9'→9
    → hash 계산 없이 배열 인덱스 직접 접근

3.  '_end' in curr_dict → is_end[node] 배열로 관리
    → dict 해시 탐색 → 배열 인덱스 직접 접근으로 단축

4. 테스트케이스마다 전체 배열 초기화 → 사용한 노드만 초기화
    → O(MAX_NODES) → O(node_count) 로 단축
<br>

<!-- ----- 여기까지 복사 ----- -->
<!-- ----- 여기부터 복사 ----- -->
---
## 🎈BOJ1261 : 알고스팟 (G4)
알고스팟 운영진이 모두 미로에 갇혔다. 미로는 N*M 크기이며, 총 1*1크기의 방으로 이루어져 있다. 미로는 빈 방 또는 벽으로 이루어져 있고, 빈 방은 자유롭게 다닐 수 있지만, 벽은 부수지 않으면 이동할 수 없다.

알고스팟 운영진은 여러명이지만, 항상 모두 같은 방에 있어야 한다. 즉, 여러 명이 다른 방에 있을 수는 없다. 어떤 방에서 이동할 수 있는 방은 상하좌우로 인접한 빈 방이다. 즉, 현재 운영진이 (x, y)에 있을 때, 이동할 수 있는 방은 (x+1, y), (x, y+1), (x-1, y), (x, y-1) 이다. 단, 미로의 밖으로 이동 할 수는 없다.

벽은 평소에는 이동할 수 없지만, 알고스팟의 무기 AOJ를 이용해 벽을 부수어 버릴 수 있다. 벽을 부수면, 빈 방과 동일한 방으로 변한다.

만약 이 문제가 [알고스팟](https://www.algospot.com/)에 있다면, 운영진들은 궁극의 무기 sudo를 이용해 벽을 한 번에 다 없애버릴 수 있지만, 안타깝게도 이 문제는 [Baekjoon Online Judge](https://www.acmicpc.net/)에 수록되어 있기 때문에, sudo를 사용할 수 없다.

현재 (1, 1)에 있는 알고스팟 운영진이 (N, M)으로 이동하려면 벽을 최소 몇 개 부수어야 하는지 구하는 프로그램을 작성하시오.

입력
첫째 줄에 미로의 크기를 나타내는 가로 크기 M, 세로 크기 N (1 ≤ N, M ≤ 100)이 주어진다. 다음 N개의 줄에는 미로의 상태를 나타내는 숫자 0과 1이 주어진다. 0은 빈 방을 의미하고, 1은 벽을 의미한다.

(1, 1)과 (N, M)은 항상 뚫려있다.

출력
첫째 줄에 알고스팟 운영진이 (N, M)으로 이동하기 위해 벽을 최소 몇 개 부수어야 하는지 출력한다.
<br>

#### 🗨 해결방법 :
bfs에서 0이면 appendleft, 1이면 append하는 방식으로 0인 길을 먼저 가보기
1로 가는 경우, 거리를 갱신하고, 거리가 더 짧은 경우 갱신하기
<br>


#### 📝메모 : 
현재 시간복잡도 : O(N × M) / 공간복잡도 : O(N × M)

    노드 수 V = N × M = 최대 100 × 100 = 10,000
    간선 수 E = 4 × N × M (상하좌우 4방향)
    0-1 BFS 1회 수행 = O(V + E) = O(5 × N × M) = O(N × M)
    각 칸은 new_cost < dist 조건일 때만 큐에 재추가
    deque 최대 크기 = O(N × M)
    방향벡터 [(0,1),(1,0),(0,-1),(-1,0)] = 루프마다 리스트 생성 발생
    float('inf') = 정수보다 느린 float 비교 연산
    board[ni][nj] = 2D 인덱싱 2번 접근
    dist[ti][tj] = 2D 인덱싱 2번 접근
    전역 dist, board = bfs() 내부에서 매번 LEGB 룰 탐색 발생

최적화 방법 :

1. float('inf') → n * m + 1 정수로 변경
→ 벽 최대 개수 = 10,000 이므로 10,001이면 INF로 충분
→ 정수 비교가 float보다 빠름

2. board 2D → 1D 평탄화 board.extend()
→ 2D 인덱싱 2번 → 1D 인덱싱 1번으로 단축
→ 메모리 연속 할당으로 캐시 히트율 향상

3. dist 2D → 1D 평탄화
→ 동일하게 인덱싱 2번 → 1번으로 단축

4. 방향벡터 DIRS = ((0,1),(1,0),(0,-1),(-1,0)) 전역 상수 선언
→ 루프 40,000번 리스트 생성 → 전역 1번 tuple 생성으로 단축
→ tuple이 list보다 메모리 적게 사용

5. _dist = dist / _board = board 지역 바인딩
→ 전역 참조 LEGB 탐색 제거, 지역변수 접근이 더 빠름

6. cur = ti * m + tj 루프 밖에서 1번만 계산
→ 매 방향 탐색마다 중복 계산 제거
<br>

<!-- ----- 여기까지 복사 ----- -->
<!-- ----- 여기부터 복사 ----- -->
---
## 🎈swea/boj - 문제이름
<br>

#### 🗨 해결방법 :
<br>


#### 📝메모 : 
<br>

<!-- ----- 여기까지 복사 ----- -->
<!-- ----- 여기부터 복사 ----- -->
---
## 🎈swea/boj - 문제이름
<br>

#### 🗨 해결방법 :
<br>


#### 📝메모 : 
<br>

<!-- ----- 여기까지 복사 ----- -->
<!-- ----- 여기부터 복사 ----- -->
---
## 🎈swea/boj - 문제이름
<br>

#### 🗨 해결방법 :
<br>


#### 📝메모 : 
<br>

<!-- ----- 여기까지 복사 ----- -->