### PR TITLE
bigskyyang / 4월 2주차

### DIFF
--- a/bigsky/BOJ/Python/boj1200.py
+++ b/bigsky/BOJ/Python/boj1200.py
@@ -1,0 +1,89 @@
+# BOJ1200: 기상예측
+import sys
+from itertools import combinations
+
+input = sys.stdin.readline
+N, M, R, S = map(int, input().split())
+
+board = []
+max_val = 0
+for _ in range(N):
+    row = list(map(int, input().split()))
+    board.append(row)
+    max_val += sum(row)
+
+col_slice_sum = [[[0] * M for _ in range(N)] for _ in range(N)]
+for c in range(M):
+    for i in range(N):
+        s = 0
+        for j in range(i, N):
+            s += board[j][c]
+            col_slice_sum[i][j][c] = s
+
+comb_data = []
+for cuts in combinations(range(1, N), R):
+    intervals = []
+    prev = 0
+    for cut in cuts:
+        intervals.append((prev, cut - 1))
+        prev = cut
+    intervals.append((prev, N - 1))
+
+    col_sums_for_comb = []
+    max_single_col_sum = 0
+    for c in range(M):
+        c_sums = [col_slice_sum[start][end][c] for start, end in intervals]
+        col_sums_for_comb.append(c_sums)
+
+        c_max = max(c_sums)
+        if c_max > max_single_col_sum:
+            max_single_col_sum = c_max
+
+    comb_data.append((max_single_col_sum, col_sums_for_comb))
+
+left = 0
+right = max_val
+answer = max_val
+
+while left <= right:
+    mid = (left + right) // 2
+    possible = False
+
+    for max_single, col_sums_for_comb in comb_data:
+        if max_single > mid:
+            continue
+
+        current_sum = [0] * (R + 1)
+        cut_count = 0
+        is_valid = True
+
+        for c in range(M):
+            c_sums = col_sums_for_comb[c]
+            need_cut = False
+
+            for i in range(R + 1):
+                if current_sum[i] + c_sums[i] > mid:
+                    need_cut = True
+                    break
+
+            if need_cut:
+                cut_count += 1
+                if cut_count > S:
+                    is_valid = False
+                    break
+                current_sum = c_sums[:]
+            else:
+                for i in range(R + 1):
+                    current_sum[i] += c_sums[i]
+
+        if is_valid:
+            possible = True
+            break
+
+    if possible:
+        answer = mid
+        right = mid - 1
+    else:
+        left = mid + 1
+
+print(answer)

--- a/bigsky/BOJ/Python/boj1916.py
+++ b/bigsky/BOJ/Python/boj1916.py
@@ -1,0 +1,38 @@
+# BOJ1916: 최소비용 구하기
+from heapq import heappop, heappush
+import sys
+input = sys.stdin.readline
+
+N, M = int(input()), int(input())  # N: 도시 수 / M: 간선 수
+
+arrow = [[] for _ in range(N + 1)]  # 버스의 출발-(도착지, 비용)
+for _ in range(M):
+    a, b, cost = map(int, input().split())
+    arrow[a].append((cost, b))
+
+start, end = map(int, input().split())  # 문제의 출발지와 도착지
+
+INF = float('inf')
+memo_min = [INF] * (N + 1)
+
+pq = []
+heappush(pq, (0, start))
+memo_min[start] = 0
+
+while pq:
+    cost, c_node = heappop(pq)
+
+    if memo_min[c_node] < cost:
+        continue
+
+    if c_node == end:
+        break
+
+    for n_cost, n_node in arrow[c_node]:
+        t_cost = cost + n_cost
+
+        if t_cost < memo_min[n_node]:
+            memo_min[n_node] = t_cost
+            heappush(pq, (t_cost, n_node))
+
+print(memo_min[end])

--- a/bigsky/BOJ/Python/boj1927.py
+++ b/bigsky/BOJ/Python/boj1927.py
@@ -1,0 +1,21 @@
+# BOJ1927: 최소 힙
+from heapq import heappop, heappush
+import sys
+
+input = sys.stdin.readline
+
+N = int(input())
+min_heap = []
+
+for _ in range(N):
+    x = int(input())
+    
+    if x == 0:                            # 0이 입력되었을 때,
+        if len(min_heap) == 0:       # 힙이 비어있다면 0출력
+            print(0)
+            continue
+
+        print(heappop(min_heap))   # 그 외에는 가장 작은 값을 출력하고 힙에서 제거
+        continue
+
+    heappush(min_heap, x)


### PR DESCRIPTION
<!-- ----- 여기부터 복사 ----- -->
---
## 🎈BOJ1916: 최소비용 구하기
N개의 도시가 있다. 그리고 한 도시에서 출발하여 다른 도시에 도착하는 M개의 버스가 있다. 우리는 A번째 도시에서 B번째 도시까지 가는데 드는 버스 비용을 최소화 시키려고 한다. A번째 도시에서 B번째 도시까지 가는데 드는 최소비용을 출력하여라. 도시의 번호는 1부터 N까지이다.
<br>

#### 🗨 해결방법 :
일반적인 다익 문제. 다익정석으로 해결
<br>


#### 📝메모 : 
알고리즘 재활로 좋은 문제였음
<br>

<!-- ----- 여기까지 복사 ----- -->
<!-- ----- 여기부터 복사 ----- -->
---
## 🎈BOJ1927: 최소 힙
널리 잘 알려진 자료구조 중 최소 힙이 있다. 최소 힙을 이용하여 다음과 같은 연산을 지원하는 프로그램을 작성하시오.

배열에 자연수 x를 넣는다.
배열에서 가장 작은 값을 출력하고, 그 값을 배열에서 제거한다.
프로그램은 처음에 비어있는 배열에서 시작하게 된다.
<br>

#### 🗨 해결방법 :
일반적인 heappush, heappop을 통해 해결
<br>


#### 📝메모 : 
쉬워서 메모장으로 코딩해봄
예상치 못한 곳에서 TLE, 금방 최적화 할 수 있었음
<br>

<!-- ----- 여기까지 복사 ----- -->
<!-- ----- 여기부터 복사 ----- -->
---
## 🎈BOJ1200: 기상예측
화학이 싫어서 지구과학을 공부한 선영이가 기상예측을 하는 일을 맡게 되었다.

선영이가 기상예측을 해야 되는 지역은 N×M짜리 격자판이고 각각의 칸마다 기상예측을 하는데 걸리는 시간이 있다.

이때 선영이는 이 격자판을 적당히 나눠서 각각의 구간의 작업을 동시에 할 수 있는데 그러므로 나누어진 구간 중 작업시간의 합이 최대인 곳을 최소화 한다면 선영이의 작업량이 최소가 될 것이다. 이때 나누는 기준은 주어진 개수의 가로선과 세로선을 이용해서 나누면 된다.

가로로 나눌 수 있는 선의 개수가 주어지고 세로 역시 주어진다고 할 때 나누어진 구간의 합의 최대를 최소로 하는 나누는 방법을 구하라.
<br>

#### 🗨 해결방법 :
1. 이분 탐색
최대 작업 시간을 X 이하로 맞출 수 있을 지에 대해서 탐색

2. 가로선 고정 - 조합
가로선 R개를 긋는 모든 경우의 수를 미리 다 만들어 두고, 왼쪽에서 오른쪽으로 이동하며 세로선만 신경 쓰기

3 . 그리디
가로선이 고정된 상태에서, 목표 시간을 지킬 수 있는지 확인
격자의 왼쪽부터 오른쪽 열로 한 칸씩 이동하면서 구역별로 시간을 계속 더함

격자 끝까지 이동했을 때, 그은 세로선의 개수가 허용된 S개 이하인지 확인

<br>


#### 📝메모 : 
너무너무 어려웠음
문제 접근 방식에 대해서 다시 한번 생각해볼 수 있었음.
완전탐색 -> 완전탐색의 범위를 줄이고 o/x확인문제로 시간 줄이는 것이 신선함
<br>

<!-- ----- 여기까지 복사 ----- -->
