### PR TITLE
nancykim99 / 4월 5주차

### DIFF
--- a/nancykim99/pgm/python/pgm12987.py
+++ b/nancykim99/pgm/python/pgm12987.py
@@ -1,0 +1,23 @@
+'''
+PGM12987 : 숫자 게임 (LV3)
+
+해결 방법 : 
+B와 A의 최대를 비교하고, 만약 A가 더 클 경우, A의 최댓값을 B의 최솟값과 버림으로써 최대 승점 확보
+정렬 및 그리지로 해결
+'''
+from collections import deque
+def solution(A, B):
+    A.sort()
+    B.sort()
+    A = deque(A)
+    B = deque(B)
+    ans = 0
+    while B:
+        if B[-1] > A[-1]:
+            ans += 1
+            A.pop()
+            B.pop()
+        else:
+            A.pop()
+            B.popleft()
+    return ans

--- a/nancykim99/pgm/python/pgm250136.py
+++ b/nancykim99/pgm/python/pgm250136.py
@@ -1,0 +1,37 @@
+'''
+PGM250136 : 석유 시추 (LV2)
+
+해결 방법 : 
+bfs로 1인 칸만 확인하면서, 그 하나의 덩어리의 사이즈 및 하나의 덩어리가 차지하는 컬럼들의 그룹을 찾음
+그 사이즈와 그 컬럼들을 업데이트하며, 가장 많은 사이즈를 가지고 있는 컬럼만 반환
+'''
+from collections import deque
+def solution(land):
+    n = len(land)
+    m = len(land[0])
+    visited = [[0] * m for _ in range(n)]
+    columns = [0] * m
+    def bfs(i, j):
+        q = deque([])
+        column = set()
+        q.append((i, j))
+        visited[i][j] = 1
+        column.add(j)
+        size = 1
+        while q:
+            ti, tj = q.popleft()
+            for si, sj in [(0, 1), (1, 0), (0, -1), (-1, 0)]:
+                ni, nj = ti + si, tj + sj
+                if 0<=ni<n and 0<=nj<m and land[ni][nj] == 1 and not visited[ni][nj]:
+                    q.append((ni, nj))
+                    visited[ni][nj] = 1
+                    column.add(nj)
+                    size += 1
+        for c in column:
+            columns[c] += size
+    for i in range(n):
+        for j in range(m):
+            if land[i][j] == 1 and not visited[i][j]:
+                bfs(i, j)
+    answer = max(columns)
+    return answer


### PR DESCRIPTION
<!-- ----- 여기부터 복사 ----- -->
---
## 🎈PGM250136 : 석유 시추 (LV2)
[문제 설명]
세로길이가 n 가로길이가 m인 격자 모양의 땅 속에서 석유가 발견되었습니다. 석유는 여러 덩어리로 나누어 묻혀있습니다. 당신이 시추관을 수직으로 단 하나만 뚫을 수 있을 때, 가장 많은 석유를 뽑을 수 있는 시추관의 위치를 찾으려고 합니다. 시추관은 열 하나를 관통하는 형태여야 하며, 열과 열 사이에 시추관을 뚫을 수 없습니다.
<img width="553" height="209" alt="image" src="https://github.com/user-attachments/assets/c39fa81c-6d92-4b02-a2b3-bcf8dfb3568b" />
예를 들어 가로가 8, 세로가 5인 격자 모양의 땅 속에 위 그림처럼 석유가 발견되었다고 가정하겠습니다. 상, 하, 좌, 우로 연결된 석유는 하나의 덩어리이며, 석유 덩어리의 크기는 덩어리에 포함된 칸의 수입니다. 그림에서 석유 덩어리의 크기는 왼쪽부터 8, 7, 2입니다.
<img width="585" height="249" alt="image" src="https://github.com/user-attachments/assets/d5fca868-dadd-4fe5-879a-02a6dd587e77" />
시추관은 위 그림처럼 설치한 위치 아래로 끝까지 뻗어나갑니다. 만약 시추관이 석유 덩어리의 일부를 지나면 해당 덩어리에 속한 모든 석유를 뽑을 수 있습니다. 시추관이 뽑을 수 있는 석유량은 시추관이 지나는 석유 덩어리들의 크기를 모두 합한 값입니다. 시추관을 설치한 위치에 따라 뽑을 수 있는 석유량은 다음과 같습니다.

시추관의 위치 | 획득한 덩어리 | 총 석유량
-- | -- | --
1 | [8] | 8
2 | [8] | 8
3 | [8] | 8
4 | [7] | 7
5 | [7] | 7
6 | [7] | 7
7 | [7, 2] | 9
8 | [2] | 2

오른쪽 그림처럼 7번 열에 시추관을 설치하면 크기가 7, 2인 덩어리의 석유를 얻어 뽑을 수 있는 석유량이 9로 가장 많습니다.

석유가 묻힌 땅과 석유 덩어리를 나타내는 2차원 정수 배열 land가 매개변수로 주어집니다. 이때 시추관 하나를 설치해 뽑을 수 있는 가장 많은 석유량을 return 하도록 solution 함수를 완성해 주세요.

[제한 사항]
1 ≤ land의 길이 = 땅의 세로길이 = n ≤ 500
1 ≤ land[i]의 길이 = 땅의 가로길이 = m ≤ 500
land[i][j]는 i+1행 j+1열 땅의 정보를 나타냅니다.
land[i][j]는 0 또는 1입니다.
land[i][j]가 0이면 빈 땅을, 1이면 석유가 있는 땅을 의미합니다.

[정확성 테스트 케이스 제한사항]
1 ≤ land의 길이 = 땅의 세로길이 = n ≤ 100
1 ≤ land[i]의 길이 = 땅의 가로길이 = m ≤ 100
[효율성 테스트 케이스 제한사항]
주어진 조건 외 추가 제한사항 없습니다.
<br>

#### 🗨 해결방법 :
bfs로 1인 칸만 확인하면서, 그 하나의 덩어리의 사이즈 및 하나의 덩어리가 차지하는 컬럼들의 그룹을 찾음
그 사이즈와 그 컬럼들을 업데이트하며, 가장 많은 사이즈를 가지고 있는 컬럼만 반환
<br>


#### 📝메모 : 
<br>

<!-- ----- 여기까지 복사 ----- -->
<!-- ----- 여기부터 복사 ----- -->
---
## 🎈PGM12987 : 숫자 게임 (LV3)

[문제 설명]
xx 회사의 2xN명의 사원들은 N명씩 두 팀으로 나눠 숫자 게임을 하려고 합니다. 두 개의 팀을 각각 A팀과 B팀이라고 하겠습니다. 숫자 게임의 규칙은 다음과 같습니다.

먼저 모든 사원이 무작위로 자연수를 하나씩 부여받습니다.
각 사원은 딱 한 번씩 경기를 합니다.
각 경기당 A팀에서 한 사원이, B팀에서 한 사원이 나와 서로의 수를 공개합니다. 그때 숫자가 큰 쪽이 승리하게 되고, 승리한 사원이 속한 팀은 승점을 1점 얻게 됩니다.
만약 숫자가 같다면 누구도 승점을 얻지 않습니다.
전체 사원들은 우선 무작위로 자연수를 하나씩 부여받았습니다. 그다음 A팀은 빠르게 출전순서를 정했고 자신들의 출전 순서를 B팀에게 공개해버렸습니다. B팀은 그것을 보고 자신들의 최종 승점을 가장 높이는 방법으로 팀원들의 출전 순서를 정했습니다. 이때의 B팀이 얻는 승점을 구해주세요.
A 팀원들이 부여받은 수가 출전 순서대로 나열되어있는 배열 A와 i번째 원소가 B팀의 i번 팀원이 부여받은 수를 의미하는 배열 B가 주어질 때, B 팀원들이 얻을 수 있는 최대 승점을 return 하도록 solution 함수를 완성해주세요.

[제한사항]
A와 B의 길이는 같습니다.
A와 B의 길이는 1 이상 100,000 이하입니다.
A와 B의 각 원소는 1 이상 1,000,000,000 이하의 자연수입니다.
<br>

#### 🗨 해결방법 :
B와 A의 최대를 비교하고, 만약 A가 더 클 경우, A의 최댓값을 B의 최솟값과 버림으로써 최대 승점 확보
정렬 및 그리지로 해결
<br>


#### 📝메모 : 
<br>

<!-- ----- 여기까지 복사 ----- -->
<!-- ----- 여기부터 복사 ----- -->
---
## 🎈swea/boj - 문제이름
<br>

#### 🗨 해결방법 :
<br>


#### 📝메모 : 
<br>

<!-- ----- 여기까지 복사 ----- -->
<!-- ----- 여기부터 복사 ----- -->
---
## 🎈swea/boj - 문제이름
<br>

#### 🗨 해결방법 :
<br>


#### 📝메모 : 
<br>

<!-- ----- 여기까지 복사 ----- -->
<!-- ----- 여기부터 복사 ----- -->
---
## 🎈swea/boj - 문제이름
<br>

#### 🗨 해결방법 :
<br>


#### 📝메모 : 
<br>

<!-- ----- 여기까지 복사 ----- -->