### PR TITLE
SngJuni / 5월 4주차

### DIFF
--- a/SngJuni/PGM/pgm42579.cpp
+++ b/SngJuni/PGM/pgm42579.cpp
@@ -1,0 +1,34 @@
+#include <string>
+#include <vector>
+#include <queue>
+#include <map>
+#include <algorithm>
+
+using namespace std;
+
+vector<int> solution(vector<string> genres, vector<int> plays) {
+    vector<int> answer;
+    
+    map<string, int> total;
+    map<string, priority_queue<pair<int, int>>> m;
+    
+    for (int i = 0; i < genres.size(); i++) {
+        total[genres[i]] += plays[i];
+        m[genres[i]].push({plays[i], -i});
+    }
+    
+    vector<pair<int, string>> order;
+    for (auto i : total) {
+        order.push_back({i.second, i.first});
+    }
+    
+    sort(order.rbegin(), order.rend());
+    for (int i = 0; i < order.size(); i++) {
+        for (int j = 0; !m[order[i].second].empty() && j < 2; j++) {
+            answer.push_back(-m[order[i].second].top().second);
+            m[order[i].second].pop();
+        }
+    }
+    
+    return answer;
+}

--- a/SngJuni/PGM/pgm42747.cpp
+++ b/SngJuni/PGM/pgm42747.cpp
@@ -1,0 +1,17 @@
+#include <string>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+int solution(vector<int> citations) {
+    int answer = 0;
+    
+    sort(citations.rbegin(), citations.rend());
+    
+    for (int i = 0; i < citations.size(); i++) {
+        if (citations[i] > i) answer++;
+    }
+    
+    return answer;
+}

--- a/SngJuni/PGM/pgm87946.cpp
+++ b/SngJuni/PGM/pgm87946.cpp
@@ -1,0 +1,25 @@
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+int answer = 0;
+int visited[8] = {0, };
+
+void dfs(int depth, int p, vector<vector<int>> &d) {
+    answer = max(answer, depth);
+
+    for (int i = 0; i < d.size(); i++) {
+        if (!visited[i] && p >= d[i][0]) {
+            visited[i] = true;
+            dfs(depth + 1, p - d[i][1], d);
+            visited[i] = false;
+        }
+    }
+}
+
+int solution(int k, vector<vector<int>> dungeons) {
+    dfs(0, k, dungeons);
+
+    return answer;
+}


### PR DESCRIPTION
---
## 🎈pgm42579 - 베스트앨범
[문제]
스트리밍 사이트에서 장르 별로 가장 많이 재생된 노래를 두 개씩 모아 베스트 앨범을 출시하려 합니다. 노래는 고유 번호로 구분하며, 노래를 수록하는 기준은 다음과 같습니다.

1. 속한 노래가 많이 재생된 장르를 먼저 수록합니다.
2. 장르 내에서 많이 재생된 노래를 먼저 수록합니다.
3. 장르 내에서 재생 횟수가 같은 노래 중에서는 고유 번호가 낮은 노래를 먼저 수록합니다.

노래의 장르를 나타내는 문자열 배열 genres와 노래별 재생 횟수를 나타내는 정수 배열 plays가 주어질 때, 베스트 앨범에 들어갈 노래의 고유 번호를 순서대로 return 하도록 solution 함수를 완성하세요.

[제한사항]
- genres[i]는 고유번호가 i인 노래의 장르입니다.
- plays[i]는 고유번호가 i인 노래가 재생된 횟수입니다.
- genres와 plays의 길이는 같으며, 이는 1 이상 10,000 이하입니다.
- 장르 종류는 100개 미만입니다.
- 장르에 속한 곡이 하나라면, 하나의 곡만 선택합니다.
- 모든 장르는 재생된 횟수가 다릅니다.

[입출력 예]
genres | plays | return
-- | -- | --
["classic", "pop", "classic", "classic", "pop"] | [500, 600, 150, 800, 2500] | [4, 1, 3, 0]

#### 🗨 해결방법 :
map과 priority_queue 자료구조를 사용해서 해결했다.

#### 📝메모 :

---
## 🎈pgm42747 - H-Index
[문제]
H-Index는 과학자의 생산성과 영향력을 나타내는 지표입니다. 어느 과학자의 H-Index를 나타내는 값인 h를 구하려고 합니다. 위키백과[1](https://school.programmers.co.kr/learn/courses/30/lessons/42747#fn1)에 따르면, H-Index는 다음과 같이 구합니다.

어떤 과학자가 발표한 논문 n편 중, h번 이상 인용된 논문이 h편 이상이고 나머지 논문이 h번 이하 인용되었다면 h의 최댓값이 이 과학자의 H-Index입니다.

어떤 과학자가 발표한 논문의 인용 횟수를 담은 배열 citations가 매개변수로 주어질 때, 이 과학자의 H-Index를 return 하도록 solution 함수를 작성해주세요.

[제한사항]
- 과학자가 발표한 논문의 수는 1편 이상 1,000편 이하입니다.
- 논문별 인용 횟수는 0회 이상 10,000회 이하입니다.

[입출력 예]
citations | return
-- | --
[3, 0, 6, 1, 5] | 3

[입출력 예 설명]
이 과학자가 발표한 논문의 수는 5편이고, 그중 3편의 논문은 3회 이상 인용되었습니다. 그리고 나머지 2편의 논문은 3회 이하 인용되었기 때문에 이 과학자의 H-Index는 3입니다.

#### 🗨 해결방법 :
citations 배열을 내림차순으로 정렬하고 H-Index의 정의를 사용해서 해당 값이 해당 칸의 인덱스보다 큰 칸의 갯수를 세서 해결했다.

#### 📝메모 :

---
## 🎈pgm87946 - 피로도
[문제]
XX게임에는 피로도 시스템(0 이상의 정수로 표현합니다)이 있으며, 일정 피로도를 사용해서 던전을 탐험할 수 있습니다. 이때, 각 던전마다 탐험을 시작하기 위해 필요한 "최소 필요 피로도"와 던전 탐험을 마쳤을 때 소모되는 "소모 피로도"가 있습니다. "최소 필요 피로도"는 해당 던전을 탐험하기 위해 가지고 있어야 하는 최소한의 피로도를 나타내며, "소모 피로도"는 던전을 탐험한 후 소모되는 피로도를 나타냅니다. 예를 들어 "최소 필요 피로도"가 80, "소모 피로도"가 20인 던전을 탐험하기 위해서는 유저의 현재 남은 피로도는 80 이상 이어야 하며, 던전을 탐험한 후에는 피로도 20이 소모됩니다.

이 게임에는 하루에 한 번씩 탐험할 수 있는 던전이 여러개 있는데, 한 유저가 오늘 이 던전들을 최대한 많이 탐험하려 합니다. 유저의 현재 피로도 k와 각 던전별 "최소 필요 피로도", "소모 피로도"가 담긴 2차원 배열 dungeons 가 매개변수로 주어질 때, 유저가 탐험할수 있는 최대 던전 수를 return 하도록 solution 함수를 완성해주세요.

[제한사항]
- k는 1 이상 5,000 이하인 자연수입니다.
- dungeons의 세로(행) 길이(즉, 던전의 개수)는 1 이상 8 이하입니다.
  - dungeons의 가로(열) 길이는 2 입니다.
  - dungeons의 각 행은 각 던전의 ["최소 필요 피로도", "소모 피로도"] 입니다.
  - "최소 필요 피로도"는 항상 "소모 피로도"보다 크거나 같습니다.
  - "최소 필요 피로도"와 "소모 피로도"는 1 이상 1,000 이하인 자연수입니다.
  - 서로 다른 던전의 ["최소 필요 피로도", "소모 피로도"]가 서로 같을 수 있습니다.

[입출력 예]
k | dungeons | result
-- | -- | --
80 | [[80,20],[50,40],[30,10]] | 3

[입출력 예 설명]
현재 피로도는 80입니다.

만약, 첫 번째 → 두 번째 → 세 번째 던전 순서로 탐험한다면

- 현재 피로도는 80이며, 첫 번째 던전을 돌기위해 필요한 "최소 필요 피로도" 또한 80이므로, 첫 번째 던전을 탐험할 수 있습니다. 첫 번째 던전의 "소모 피로도"는 20이므로, 던전을 탐험한 후 남은 피로도는 60입니다.
- 남은 피로도는 60이며, 두 번째 던전을 돌기위해 필요한 "최소 필요 피로도"는 50이므로, 두 번째 던전을 탐험할 수 있습니다. 두 번째 던전의 "소모 피로도"는 40이므로, 던전을 탐험한 후 남은 피로도는 20입니다.
- 남은 피로도는 20이며, 세 번째 던전을 돌기위해 필요한 "최소 필요 피로도"는 30입니다. 따라서 세 번째 던전은 탐험할 수 없습니다.

만약, 첫 번째 → 세 번째 → 두 번째 던전 순서로 탐험한다면

- 현재 피로도는 80이며, 첫 번째 던전을 돌기위해 필요한 "최소 필요 피로도" 또한 80이므로, 첫 번째 던전을 탐험할 수 있습니다. 첫 번째 던전의 "소모 피로도"는 20이므로, 던전을 탐험한 후 남은 피로도는 60입니다.
- 남은 피로도는 60이며, 세 번째 던전을 돌기위해 필요한 "최소 필요 피로도"는 30이므로, 세 번째 던전을 탐험할 수 있습니다. 세 번째 던전의 "소모 피로도"는 10이므로, 던전을 탐험한 후 남은 피로도는 50입니다.
- 남은 피로도는 50이며, 두 번째 던전을 돌기위해 필요한 "최소 필요 피로도"는 50이므로, 두 번째 던전을 탐험할 수 있습니다. 두 번째 던전의 "소모 피로도"는 40이므로, 던전을 탐험한 후 남은 피로도는 10입니다.

따라서 이 경우 세 던전을 모두 탐험할 수 있으며, 유저가 탐험할 수 있는 최대 던전 수는 3입니다.

#### 🗨 해결방법 :
DFS+백트래킹을 사용해서 해결했다.

#### 📝메모 :